### PR TITLE
Rock Pi S enable and fix tsadc

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
@@ -743,7 +743,7 @@
 			polling-delay = <1000>;
 			sustainable-power = <300>;
 
-			thermal-sensors = <&tsadc 0>;
+			thermal-sensors = <&tsadc 1>;
 
 			trips {
 				threshold: trip-point-0 {
@@ -777,7 +777,7 @@
 			polling-delay-passive = <100>; /* milliseconds */
 			polling-delay = <1000>; /* milliseconds */
 
-			thermal-sensors = <&tsadc 1>;
+			thermal-sensors = <&tsadc 0>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rockpi-s-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rockpi-s-linux.dts
@@ -322,6 +322,12 @@
 	status = "okay";
 };
 
+&tsadc {
+	rockchip,hw-tshut-mode = <0>;		/* 0:CRU */
+	rockchip,hw-tshut-polarity = <1>;	/* 1:HIGH */
+	status = "okay";
+};
+
 &u2phy {
 	status = "okay";
 


### PR DESCRIPTION
Enabled tsadc and fixed channels assignment for thermal zones.

RK3308 TRM Part 1
26.5.1 Channel Select
The system has two Temperature Sensors, channel 0 is for logic power domain and channel 1 is for core power domain.