### PR TITLE
Add initial support for Radxa Zero 2

### DIFF
--- a/Documentation/devicetree/bindings/arm/amlogic.yaml
+++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
@@ -146,6 +146,7 @@ properties:
         items:
           - enum:
               - khadas,vim3
+              - radxa,zero2
           - const: amlogic,a311d
           - const: amlogic,g12b
 

--- a/arch/arm64/boot/dts/amlogic/Makefile
+++ b/arch/arm64/boot/dts/amlogic/Makefile
@@ -10,6 +10,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb
+dtb-$(CONFIG_ARCH_MESON) += meson-g12b-radxa-zero2.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ugoos-am6.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-kii-pro.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-nanopi-k2.dtb

--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
@@ -840,6 +840,22 @@
 						};
 					};
 
+					pwm_b_h7_pins: pwm-b-h7 {
+						mux {
+							groups = "pwm_b_h7";
+							function = "pwm_b";
+							bias-disable;
+						};
+					};
+
+					pwm_b_z0_pins: pwm-b-z0 {
+						mux {
+							groups = "pwm_b_z0";
+							function = "pwm_b";
+							bias-disable;
+						};
+					};
+
 					pwm_c_c_pins: pwm-c-c {
 						mux {
 							groups = "pwm_c_c";
@@ -864,6 +880,14 @@
 						};
 					};
 
+					pwm_c_z1_pins: pwm-c-z1 {
+						mux {
+							groups = "pwm_c_z1";
+							function = "pwm_c";
+							bias-disable;
+						};
+					};
+
 					pwm_d_x3_pins: pwm-d-x3 {
 						mux {
 							groups = "pwm_d_x3";
@@ -875,6 +899,14 @@
 					pwm_d_x6_pins: pwm-d-x6 {
 						mux {
 							groups = "pwm_d_x6";
+							function = "pwm_d";
+							bias-disable;
+						};
+					};
+
+					pwm_d_z2_pins: pwm-d-z2 {
+						mux {
+							groups = "pwm_d_z2";
 							function = "pwm_d";
 							bias-disable;
 						};

--- a/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2019 BayLibre, SAS
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
+ * Copyright (c) 2022 Radxa Limited
+ * Author: Yuntian Zhang <yt@radxa.com>
+ */
+
+/dts-v1/;
+
+#include "meson-g12b-a311d.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+	model = "Radxa Zero2";
+
+	aliases {
+		serial0 = &uart_AO;
+		serial2 = &uart_A;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+		power-button {
+			label = "power";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio_ao GPIOAO_3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio GPIOA_12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	cvbs-connector {
+		status = "disabled";
+		compatible = "composite-video-connector";
+
+		port {
+			cvbs_connector_in: endpoint {
+				remote-endpoint = <&cvbs_vdac_out>;
+			};
+		};
+	};
+
+	hdmi-connector {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi_connector_in: endpoint {
+				remote-endpoint = <&hdmi_tx_tmds_out>;
+			};
+		};
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
+		clocks = <&wifi32k>;
+		clock-names = "ext_clock";
+	};
+
+	ao_5v: regulator-ao_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "AO_5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vcc_1v8: regulator-vcc_1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC_1V8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vcc_3v3>;
+		regulator-always-on;
+	};
+
+	vcc_3v3: regulator-vcc_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+		/* FIXME: actually controlled by VDDCPU_B_EN */
+	};
+
+	vddao_1v8: regulator-vddao_1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_AO1V8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vddao_3v3: regulator-vddao_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDAO_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&ao_5v>;
+		regulator-always-on;
+	};
+
+	vddcpu_a: regulator-vddcpu-a {
+		/*
+		 * MP8756GD Regulator.
+		 */
+		compatible = "pwm-regulator";
+
+		regulator-name = "VDDCPU_A";
+		regulator-min-microvolt = <730000>;
+		regulator-max-microvolt = <1010000>;
+
+		pwm-supply = <&ao_5v>;
+
+		pwms = <&pwm_ab 0 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vddcpu_b: regulator-vddcpu-b {
+		/*
+		 * Silergy SY8120B1ABC Regulator.
+		 */
+		compatible = "pwm-regulator";
+
+		regulator-name = "VDDCPU_B";
+		regulator-min-microvolt = <730000>;
+		regulator-max-microvolt = <1010000>;
+
+		pwm-supply = <&ao_5v>;
+
+		pwms = <&pwm_AO_cd 1 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	sound {
+		compatible = "amlogic,axg-sound-card";
+		model = "RADXA-ZERO2";
+		audio-aux-devs = <&tdmout_b>;
+		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
+				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
+				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
+				"TDM_B Playback", "TDMOUT_B OUT";
+
+		assigned-clocks = <&clkc CLKID_MPLL2>,
+				  <&clkc CLKID_MPLL0>,
+				  <&clkc CLKID_MPLL1>;
+		assigned-clock-parents = <0>, <0>, <0>;
+		assigned-clock-rates = <294912000>,
+				       <270950400>,
+				       <393216000>;
+		status = "okay";
+
+		dai-link-0 {
+			sound-dai = <&frddr_a>;
+		};
+
+		dai-link-1 {
+			sound-dai = <&frddr_b>;
+		};
+
+		dai-link-2 {
+			sound-dai = <&frddr_c>;
+		};
+
+		/* 8ch hdmi interface */
+		dai-link-3 {
+			sound-dai = <&tdmif_b>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			dai-tdm-slot-tx-mask-1 = <1 1>;
+			dai-tdm-slot-tx-mask-2 = <1 1>;
+			dai-tdm-slot-tx-mask-3 = <1 1>;
+			mclk-fs = <256>;
+
+			codec {
+				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
+			};
+		};
+
+		/* hdmi glue */
+		dai-link-4 {
+			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
+
+			codec {
+				sound-dai = <&hdmi_tx>;
+			};
+		};
+	};
+
+	wifi32k: wifi32k {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
+	};
+};
+
+&arb {
+	status = "okay";
+};
+
+&cec_AO {
+	pinctrl-0 = <&cec_ao_a_h_pins>;
+	pinctrl-names = "default";
+	status = "disabled";
+	hdmi-phandle = <&hdmi_tx>;
+};
+
+&cecb_AO {
+	pinctrl-0 = <&cec_ao_b_h_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	hdmi-phandle = <&hdmi_tx>;
+};
+
+&clkc_audio {
+	status = "okay";
+};
+
+&cpu0 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu1 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu100 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu101 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu102 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu103 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cvbs_vdac_port {
+	cvbs_vdac_out: endpoint {
+		remote-endpoint = <&cvbs_connector_in>;
+	};
+};
+
+&frddr_a {
+	status = "okay";
+};
+
+&frddr_b {
+	status = "okay";
+};
+
+&frddr_c {
+	status = "okay";
+};
+
+&gpio {
+	gpio-line-names =
+		/* GPIOZ */
+		"PIN_27", "PIN_28", "PIN_7", "PIN_11", "PIN_13", "PIN_15", "PIN_18", "PIN_40",
+		"", "", "", "", "", "", "", "",
+		/* GPIOH */
+		"", "", "", "", "PIN_19", "PIN_21", "PIN_24", "PIN_23",
+		"",
+		/* BOOT */
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "EMMC_PWRSEQ", "", "", "",
+		/* GPIOC */
+		"", "", "", "", "", "", "SD_CD", "PIN_36",
+		/* GPIOA */
+		"PIN_32", "PIN_12", "PIN_35", "", "", "PIN_38", "", "",
+		"", "", "", "", "LED_GREEN", "PIN_31", "PIN_3", "PIN_5",
+		/* GPIOX */
+		"", "", "", "", "", "", "SDIO_PWRSEQ", "",
+		"", "", "", "", "", "", "", "",
+		"", "BT_SHUTDOWN", "", "";
+};
+
+&gpio_ao {
+	gpio-line-names =
+		/* GPIOAO */
+		"PIN_8", "PIN_10", "", "BTN_POWER", "", "", "", "PIN_29",
+		"PIN_33", "PIN_37", "FAN", "",
+		/* GPIOE */
+		"", "", "";
+};
+
+&hdmi_tx {
+	status = "okay";
+	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
+	pinctrl-names = "default";
+	hdmi-supply = <&ao_5v>;
+};
+
+&hdmi_tx_tmds_port {
+	hdmi_tx_tmds_out: endpoint {
+		remote-endpoint = <&hdmi_connector_in>;
+	};
+};
+
+&ir {
+	status = "disabled";
+	pinctrl-0 = <&remote_input_ao_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_ab {
+	pinctrl-0 = <&pwm_a_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin0";
+	status = "okay";
+};
+
+&pwm_ef {
+	pinctrl-0 = <&pwm_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin2";
+	status = "okay";
+};
+
+&pwm_AO_cd {
+	pinctrl-0 = <&pwm_ao_d_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin4";
+	status = "okay";
+};
+
+&saradc {
+	status = "okay";
+	vref-supply = <&vddao_1v8>;
+};
+
+/* SDIO */
+&sd_emmc_a {
+	status = "okay";
+	pinctrl-0 = <&sdio_pins>;
+	pinctrl-1 = <&sdio_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	bus-width = <4>;
+	cap-sd-highspeed;
+	max-frequency = <100000000>;
+
+	non-removable;
+	disable-wp;
+
+	/* WiFi firmware requires power to be kept while in suspend */
+	keep-power-in-suspend;
+
+	mmc-pwrseq = <&sdio_pwrseq>;
+
+	vmmc-supply = <&vddao_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+
+	brcmf: wifi@1 {
+		reg = <1>;
+		compatible = "brcm,bcm4329-fmac";
+	};
+};
+
+/* SD card */
+&sd_emmc_b {
+	status = "okay";
+	pinctrl-0 = <&sdcard_c_pins>;
+	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <4>;
+	cap-sd-highspeed;
+	max-frequency = <50000000>;
+	disable-wp;
+
+	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
+	vmmc-supply = <&vddao_3v3>;
+	vqmmc-supply = <&vddao_3v3>;
+};
+
+/* eMMC */
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	max-frequency = <200000000>;
+	disable-wp;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+	vmmc-supply = <&vcc_3v3>;
+	vqmmc-supply = <&vcc_1v8>;
+};
+
+&tdmif_b {
+	status = "okay";
+};
+
+&tdmout_b {
+	status = "okay";
+};
+
+&tohdmitx {
+	status = "okay";
+};
+
+&uart_A {
+	status = "okay";
+	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
+	pinctrl-names = "default";
+	uart-has-rtscts;
+
+	bluetooth {
+		compatible = "brcm,bcm43438-bt";
+		shutdown-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
+		max-speed = <2000000>;
+		clocks = <&wifi32k>;
+		clock-names = "lpo";
+	};
+};
+
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+&usb {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/Makefile
+++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
@@ -10,7 +10,21 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-uart-ao-a-on-gpioao-0-gpioao-1.dtbo \
 	meson-g12a-uart-ao-b-on-gpioao-2-gpioao-3.dtbo \
 	meson-g12a-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
-	meson-g12a-uart-ee-c.dtbo
+	meson-g12a-uart-ee-c.dtbo \
+	meson-g12b-i2c-ee-m0-gpioz-0-1.dtbo \
+	meson-g12b-i2c-ee-m0-gpioz-1-7.dtbo \
+	meson-g12b-i2c-ee-m1-gpioh-6-7.dtbo \
+	meson-g12b-i2c-ee-m3-gpioa-14-15.dtbo \
+	meson-g12b-pwm-b-gpioh-7.dtbo \
+	meson-g12b-pwm-b-gpioz-0.dtbo \
+	meson-g12b-pwm-c-gpioz-1.dtbo \
+	meson-g12b-pwm-d-gpioz-2.dtbo \
+	meson-g12b-pwm-c-d-gpioz-1-2.dtbo \
+	meson-g12b-pwm-f-gpioh-5.dtbo \
+	meson-g12b-spi-b-gpioh-4-5-6-7.dtbo \
+	meson-g12b-uart-ao-a-gpioao-0-1.dtbo \
+	meson-g12b-uart-ao-b-gpioao-8-9.dtbo \
+	meson-g12b-uart-ee-c-gpioh-4-5-6-7.dtbo
 
 scr-$(CONFIG_ARCH_MESON) += \
 	meson-fixup.scr

--- a/arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays
+++ b/arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays
@@ -4,10 +4,13 @@ This document describes overlays provided in the kernel packages.
 For generic device tree overlays documentation please see
 https://wiki.radxa.com/Device-tree-overlays
 
-## Platform and Chips:
+## Platform and Chips
 
 Amlogic
 - meson-g12a / S905Y2
+- meson-g12b / A311D
+
+### g12a
 
 #### usage
 
@@ -166,3 +169,56 @@ param_spidev_max_freq (int)
     Default: 10000000
     Range: 3000 - 100000000
 
+### g12b
+
+#### Usage
+
+Kernel provided DT overlay files are in `/boot/dtbs/$(uname -r)/amlogic/overlay`
+
+`/boot/uEnv.txt` syntax:
+
+    overlays=<space-seprated-list-of-overlays>
+
+#### How to read the overlay file name
+
+The overlay file name follows the following convention:
+
+    <soc-family>-<soc-variant>-<function>-<location>-<gpio-bank>-<gpio-pins>
+
+- soc-family: must be `meson`
+- soc-variant: can be one of `g12a`, or `g12b`. For Radxa Zero2, use `g12b` variant.
+- function: can be one of `i2c`, `pwm`, `spi`, or `uart`
+- location: specify the exact controller that implements the function
+- gpio-bank & gpio-pins: specify the exact GPIO pins that is muxed with the function
+
+You can specify multiple overlays in `/boot/uEnv.txt`.
+However, for any given pin they can only have 1 function,
+and for any given function they can only have 1 set of pins.
+
+For example, you cannot specify both `meson-g12b-i2c-ee-m0-gpioz-0-1`
+and `meson-g12b-i2c-ee-m0-gpioz-1-7` at the same time,
+as that assigned the same `i2c-ee-m0` function to 2 different sets of pins.
+
+#### Available overlays
+
+##### I2C
+- meson-g12b-i2c-ee-m0-gpioz-0-1
+- meson-g12b-i2c-ee-m0-gpioz-1-7
+- meson-g12b-i2c-ee-m1-gpioh-6-7
+- meson-g12b-i2c-ee-m3-gpioa-14-15
+
+##### PWM
+- meson-g12b-pwm-b-gpioh-7
+- meson-g12b-pwm-b-gpioz-0
+- meson-g12b-pwm-c-gpioz-1
+- meson-g12b-pwm-d-gpioz-2
+- meson-g12b-pwm-c-d-gpioz-1-2
+- meson-g12b-pwm-f-gpioh-5
+
+##### SPI
+- meson-g12b-spi-b-gpioh-4-5-6-7
+
+##### UART
+- meson-g12b-uart-ao-a-gpioao-0-1
+- meson-g12b-uart-ao-b-gpioao-8-9
+- meson-g12b-uart-ee-c-gpioh-4-5-6-7

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m0-gpioz-0-1.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m0-gpioz-0-1.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c0>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c0_sck_z1_pins &i2c0_sda_z0_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m0-gpioz-1-7.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m0-gpioz-1-7.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c0>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c0_sck_z1_pins &i2c0_sda_z7_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m1-gpioh-6-7.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m1-gpioh-6-7.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c1_sck_h7_pins &i2c1_sda_h6_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m3-gpioa-14-15.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-i2c-ee-m3-gpioa-14-15.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c3>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c3_sck_a_pins &i2c3_sda_a_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-b-gpioh-7.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-b-gpioh-7.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_ab>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_a_e_pins &pwm_b_h7_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin0";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-b-gpioz-0.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-b-gpioz-0.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_ab>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_a_e_pins &pwm_b_z0_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin0";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-c-d-gpioz-1-2.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-c-d-gpioz-1-2.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_cd>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_c_z1_pins &pwm_d_z2_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin1";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-c-gpioz-1.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-c-gpioz-1.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_cd>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_c_z1_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin1";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-d-gpioz-2.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-d-gpioz-2.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_cd>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_d_z2_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin1";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-f-gpioh-5.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-pwm-f-gpioh-5.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&pwm_ef>;
+		__overlay__ {
+			pinctrl-0 = <&pwm_e_pins &pwm_f_h_pins>;
+			pinctrl-names = "default";
+			clocks = <&xtal>;
+			clock-names = "clkin2";
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-spi-b-gpioh-4-5-6-7.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-spi-b-gpioh-4-5-6-7.dts
@@ -1,0 +1,23 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&spicc1>;
+		__overlay__ {
+			pinctrl-0 = <&spicc1_pins &spicc1_ss0_pins>;
+			pinctrl-names = "default";
+			#address-cells = <1>;
+			#size-cells = <0>;
+            status = "okay";
+			spidev@0 {
+				compatible = "linux,spidev";
+				status = "okay";
+				spi-max-frequency = <10000000>;
+				reg = <0>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ao-a-gpioao-0-1.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ao-a-gpioao-0-1.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&uart_AO>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart_ao_a_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ao-b-gpioao-8-9.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ao-b-gpioao-8-9.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&uart_AO_B>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart_ao_b_tx_8_rx_9_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ee-c-gpioh-4-5-6-7.dts
+++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-uart-ee-c-gpioh-4-5-6-7.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&uart_C>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart_c_pins &uart_c_cts_rts_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};

--- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
@@ -269,15 +269,19 @@ static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
 /* pwm_b */
 static const unsigned int pwm_b_x7_pins[]		= { GPIOX_7 };
 static const unsigned int pwm_b_x19_pins[]		= { GPIOX_19 };
+static const unsigned int pwm_b_h7_pins[]		= { GPIOH_7 };
+static const unsigned int pwm_b_z0_pins[]		= { GPIOZ_0 };
 
 /* pwm_c */
 static const unsigned int pwm_c_c_pins[]		= { GPIOC_4 };
 static const unsigned int pwm_c_x5_pins[]		= { GPIOX_5 };
 static const unsigned int pwm_c_x8_pins[]		= { GPIOX_8 };
+static const unsigned int pwm_c_z1_pins[]		= { GPIOZ_1 };
 
 /* pwm_d */
 static const unsigned int pwm_d_x3_pins[]		= { GPIOX_3 };
 static const unsigned int pwm_d_x6_pins[]		= { GPIOX_6 };
+static const unsigned int pwm_d_z2_pins[]		= { GPIOZ_2 };
 
 /* pwm_e */
 static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
@@ -588,6 +592,9 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
 	GROUP(bt565_a_din5,		2),
 	GROUP(bt565_a_din6,		2),
 	GROUP(bt565_a_din7,		2),
+	GROUP(pwm_b_z0,			5),
+	GROUP(pwm_c_z1,			5),
+	GROUP(pwm_d_z2,			2),
 	GROUP(tsin_b_valid_z,		3),
 	GROUP(tsin_b_sop_z,		3),
 	GROUP(tsin_b_din0_z,		3),
@@ -719,6 +726,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
 	GROUP(uart_c_rts,		2),
 	GROUP(iso7816_clk_h,		1),
 	GROUP(iso7816_data_h,		1),
+	GROUP(pwm_b_h7,			5),
 	GROUP(pwm_f_h,			4),
 	GROUP(cec_ao_a_h,		4),
 	GROUP(cec_ao_b_h,		5),
@@ -1053,15 +1061,15 @@ static const char * const pwm_a_groups[] = {
 };
 
 static const char * const pwm_b_groups[] = {
-	"pwm_b_x7", "pwm_b_x19",
+	"pwm_b_x7", "pwm_b_x19", "pwm_b_h7", "pwm_b_z0",
 };
 
 static const char * const pwm_c_groups[] = {
-	"pwm_c_c", "pwm_c_x5", "pwm_c_x8",
+	"pwm_c_c", "pwm_c_x5", "pwm_c_x8", "pwm_c_z1",
 };
 
 static const char * const pwm_d_groups[] = {
-	"pwm_d_x3", "pwm_d_x6",
+	"pwm_d_x3", "pwm_d_x6", "pwm_d_z2",
 };
 
 static const char * const pwm_e_groups[] = {


### PR DESCRIPTION
The following features are tested on **Radxa Zero 2 v1.0** with Armbian image and Armbian's `5.10.81-meson64` kernel, except the sole exception on PWM_B/C/D functions which require this patched kernel:

- [x] eMMC: system bootable
- [x] microSD: system bootable
- [x] WiFi: able to connect to our 5G network
- [x] USB 3: able to operate with USB 3 SSD and USB 2 mouse/keyboard, and support reverse insertion
- [x] USB 2 OTG: tested with mass storage and Ethernet gadget
- [x] HDMI: video works, audio requires [`alsa-utils`](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/audio/alsa-utils)
- [x] LED: green led heartbeating, can be configured in sysfs
- [x] Power button: can trigger shutdown after update Armbian's kernel (shipped with `5.10.60-meson64` in the downloaded image and that didn't work), custom event handler works after installing `acpid`
- [x] Bluetooth: can discover, broadcast, and pair. Didn't test further since Bluetooth is kinda a pain to use.
- [x] GPIO: every pin except 36 works for both input and output. Pin 36 is an open drain pin so it can only do input in the current hardware reversion. **Might need a pull up for this pin.**
- [x] I2C: I2C-0 can work in 2 configurations, I2C-1&3 tested working
- [x] PWM: PWM_F works with mainline kernel, PWM_B/C/D works with (this) patched kernel, PWM_B works in 2 configurations
- [x] SPI: observed correct output with `spi-pipe` and a logic analyser
- [x] UART: AO_B works as default debug console and in shorted echo mode. EE_C works in shorted echo mode, and shorted echo mode with hardware flow control.
- [ ] PWM Fan: PWM generator is not available since that is used by VDDCPU_B. Need to choose a different pin as bit banging PWM consumes unnecessary CPU cycles.
- [ ] CSI: missing testing hardware
- [ ] DSI: missing testing hardware