### PR TITLE
arm64: dts: rockpi-4cplus: add user-led1

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -191,6 +191,12 @@
 		compatible = "gpio-leds";
 		status = "okay";
 
+		user-led1 {
+			gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+			default-state = "on";
+		};
+
 		user-led2 {
 			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";


### PR DESCRIPTION
Add an entry for the green "power" led, so it can be controlled
in the same way as the red/blue "status" led. By default it is set
to just be on so it functions as before.

Signed-off-by: Marco Nelissen <marco.nelissen@gmail.com>