### PR TITLE
arm64: dts: rockchip: align status(blue) LED behavior

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -171,11 +171,13 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	leds: leds {
+	leds {
 		compatible = "gpio-leds";
-		sta_led: sta {
+
+		system-status {
+			label = "blue:status";
 			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "timer";
+			linux,default-trigger = "heartbeat";
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -155,9 +155,11 @@
 		pinctrl-0 = <&usbwifibt_6252b_drv>;
 	};
 
-	leds: leds {
+	leds {
 		compatible = "gpio-leds";
-		sta_led: sta {
+
+		system-status {
+			label = "blue:status";
 			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
 		};


### PR DESCRIPTION
label is blue:status, default trigger is heartbeat.

Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>