### PR TITLE
Linux 5.10.y: ethernet, wifi, leds, nvme and otg for Rock Pi 4C+

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -113,6 +113,31 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		clocks = <&rk809 1>;
+		clock-names = "ext_clock";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_enable_h>;
+
+		/*
+		 * On the module itself this is one of these (depending
+		 * on the actual card populated):
+		 * - SDIO_RESET_L_WL_REG_ON
+		 * - PDN (power down when low)
+		 */
+		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
+	};
+
+	wireless_wlan: wireless-wlan {
+		compatible = "wlan-platdata";
+		rockchip,grf = <&grf>;
+		wifi_chip_type = "ap6256";
+		sdio_vref = <1800>;
+		WIFI,host_wake_irq = <&gpio0 RK_PA3 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+
 	gpio-leds {
 		compatible = "gpio-leds";
 		status = "okay";
@@ -467,6 +492,23 @@
 	status = "okay";
 };
 
+&sdio0 {
+	max-frequency = <200000000>;
+	supports-sdio;
+	bus-width = <4>;
+	disable-wp;
+	cap-sd-highspeed;
+	cap-sdio-irq;
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	non-removable;
+	num-slots = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
+	sd-uhs-sdr104;
+	status = "okay";
+};
+
 &emmc_phy {
 	status = "okay";
 };
@@ -660,6 +702,13 @@
 		pcie_drv: pcie-drv {
 			rockchip,pins =
 				<3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	sdio-pwrseq {
+		wifi_enable_h: wifi-enable-h {
+			rockchip,pins =
+				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -112,6 +112,23 @@
 		regulator-name = "vcc3v3_pcie";
 		vin-supply = <&vcc5v0_sys>;
 	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		user-led1 {
+			gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+			default-state = "on";
+		};
+
+		user-led2 {
+			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+		};
+	};
 };
 
 &cdn_dp {
@@ -427,6 +444,7 @@
 	status = "okay";
 
 	bt656-supply = <&vcc_3v0>;
+	audio-supply = <&vcca_1v8>;
 	sdmmc-supply = <&vccio_sd>;
 	gpio1830-supply = <&vcc_3v0>;
 };

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -637,6 +637,10 @@
 	status = "okay";
 };
 
+&pcie_phy {
+	status = "okay";
+};
+
 &pcie0 {
 	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
 	num-lanes = <4>;

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -90,6 +90,28 @@
 		pinctrl-0 = <&hpd_en>;
 		dp-pwr-supply = <&vcc3v3_sys>;
 	};
+
+	vcc_0v9: vcc-0v9 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_0v9";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <900000>;
+		regulator-max-microvolt = <900000>;
+		vin-supply = <&vcc3v3_sys>;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie-regulator {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_drv>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-name = "vcc3v3_pcie";
+		vin-supply = <&vcc5v0_sys>;
+	};
 };
 
 &cdn_dp {
@@ -555,6 +577,17 @@
 	status = "okay";
 };
 
+&pcie0 {
+	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
+	num-lanes = <4>;
+	pinctrl-0 = <&pcie_clkreqnb_cpm>;
+	pinctrl-names = "default";
+	vpcie0v9-supply = <&vcc_0v9>;
+	vpcie1v8-supply = <&vcc_1v8>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
+	status = "okay";
+};
+
 &pinctrl {
 	hpd {
 		hpd_en: hpd-en {
@@ -602,6 +635,13 @@
 	vbus_host {
 		usb1_en_oc: usb1-en-oc {
 			rockchip,pins = <3 RK_PD6 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+
+	pcie {
+		pcie_drv: pcie-drv {
+			rockchip,pins =
+				<3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts
@@ -522,8 +522,7 @@
 };
 
 &tcphy0 {
-	extcon = <&virtual_pd>;
-	status = "disabled";
+	status = "okay";
 };
 
 &tcphy1 {
@@ -587,7 +586,8 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
-	dr_mode = "host";
+	extcon = <&u2phy0>;
+	dr_mode = "otg";
 };
 
 &usbdrd3_1 {


### PR DESCRIPTION
I noticed a recent [network related update](https://github.com/radxa/kernel/commit/5652d6f9c2a4e2c50ac1040c0388859381b0616f) to the 4C+ dts in the 5.10.y branch, however with that change I still didn't get working ethernet or wifi. This set of patches remedies that. I've split them into 5 separate changes that:
- fix ethernet
- enable wifi
- add entries for both leds in /sys/class/leds
- enable NVME
- enable USB3 OTG
