### PR TITLE
Fix wrong settings of M.2 bluetooth device wake up pin

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
@@ -1031,7 +1031,7 @@
 
 	wireless-bluetooth {
 		uart1_gpios: uart1-gpios {
-			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -1031,7 +1031,7 @@
 
 	wireless-bluetooth {
 		uart1_gpios: uart1-gpios {
-			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 


### PR DESCRIPTION
Bluetooth wake up pin was set to use gpio2, but according to schematic its actually using gpio4. So fix this.