### PR TITLE
extcon: extcon-pd-virtual: Fix typo on variable

### DIFF
--- a/drivers/extcon/extcon-pd-virtual.c
+++ b/drivers/extcon/extcon-pd-virtual.c
@@ -398,7 +398,7 @@ static const struct of_device_id vpd_extcon_dt_match[] = {
 	{ .compatible = "linux,extcon-pd-virtual", },
 	{ /* sentinel */ }
 };
-MODULE_DEVICE_TABLE(of, usb_extcon_dt_match);
+MODULE_DEVICE_TABLE(of, vpd_extcon_dt_match);
 
 static struct platform_driver vpd_extcon_driver = {
 	.probe		= vpd_extcon_probe,


### PR DESCRIPTION
This was required to have HDMI output in 5.19.5 kernel. Our existing 5.10.y kernel "works" without this change.

Currently both rbuild system with 5.19 and 5.10 kernel have FHD output in HDMI port when connected to 4K display, and no DP output.

Signed-off-by: ZHANG Yuntian <yt@radxa.com>