### PR TITLE
arm64: dts: rockchip: rock 5b: use more common pd definations

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -715,10 +715,7 @@
 			op-sink-microwatt = <1000000>;
 			sink-pdos =
 				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
-				 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
-				 PDO_FIXED(12000, 1500, PDO_FIXED_USB_COMM)>;
-			source-pdos =
-				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+				 PDO_VAR(5000, 20000, 5000)>;
 
 			altmodes {
 				#address-cells = <1>;


### PR DESCRIPTION
Instead of using PDO_FIXED which only define one PD defination, PDO_VAR defines all the PD definations bewteen the min volt and max volt.
In this commit I defined all the PD definations with volt from min 5V to max 20V and current up to 5A.
`power-role` of fusb302 is `sink` now so source-pdos is useless, I just delete it.