### PR TITLE
Add Bluetooth device wake up pin config

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -98,6 +98,7 @@
 		pinctrl-0 = <&uart6m1_rtsn>;
 		pinctrl-1 = <&uart6_gpios>;
 		BT,reset_gpio    = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio     = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
 		BT,wake_host_irq = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};


### PR DESCRIPTION
Bluetooth device wake up pin in M.2 E key port was forgotten to be configured in Rock 5B's device tree, so add that.