### PR TITLE
Enable hdmi-cec on the new kernel

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -569,6 +569,7 @@
 
 &hdmi0 {
 	status = "okay";
+        cec-enable = "true";
 };
 
 &hdmi0_in_vp0 {
@@ -591,6 +592,7 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd &hdmim1_tx1_scl &hdmim1_tx1_sda>;
+        cec-enable = "true";
 };
 
 &hdmi1_in_vp0 {


### PR DESCRIPTION
Enable cec-functionality on the new kernel. This has been put behind a DT property: https://github.com/radxa/kernel/commit/fd903b0aeb6bdd7fe1a18589a6316246f4dd1802