### PR TITLE
Revert "arm64: dts: rockchip: rk3588-linux: adjust MMC alias"

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-linux.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-linux.dtsi
@@ -6,8 +6,8 @@
 
 / {
 	aliases {
-		mmc0 = &sdmmc;
-		mmc1 = &sdhci;
+		mmc0 = &sdhci;
+		mmc1 = &sdmmc;
 		mmc2 = &sdio;
 	};
 


### PR DESCRIPTION
mmc0 is eMMC on mainline