### PR TITLE
clk: Disable writable debugfs files

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -3107,7 +3107,7 @@ static int clk_dump_show(struct seq_file *s, void *data)
 }
 DEFINE_SHOW_ATTRIBUTE(clk_dump);
 
-#define CLOCK_ALLOW_WRITE_DEBUGFS
+#undef CLOCK_ALLOW_WRITE_DEBUGFS
 #ifdef CLOCK_ALLOW_WRITE_DEBUGFS
 /*
  * This can be dangerous, therefore don't provide any real compile time


### PR DESCRIPTION
Revert commit https://github.com/friendlyarm/kernel-rockchip/commit/861a024 which may be safe for Android, but is not safe for Linux, but leads to a prominent warning at boot:
```
********************************************************************
**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE           **
**                                                                **
**  WRITEABLE clk DebugFS SUPPORT HAS BEEN ENABLED IN THIS KERNEL **
**                                                                **
** This means that this kernel is built to expose clk operations  **
** such as parent or rate setting, enabling, disabling, etc.      **
** to userspace, which may compromise security on your system.    **
**                                                                **
** If you see this message and you are not debugging the          **
** kernel, report this immediately to your vendor!                **
**                                                                **
**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE           **
********************************************************************
```
Also, the flag is meant for testing and debugging (Android), not for end user kernel builds.

For reference: https://github.com/friendlyarm/kernel-rockchip/pull/6 and #70

The other 5.10 branches have this unset already.