### PR TITLE
Update CM3S base device tree

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
@@ -50,6 +50,17 @@
 		startup-delay-us = <100000>;
 		vin-supply = <&vcc3v3_sys>;
 	};
+
+	vcc_ch482d: vcc-ch482d {
+		compatible = "regulator-fixed";
+		enable-active-low;
+		gpio = <&gpio0 RK_PC1 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&ch482d_en>;
+		regulator-name = "vcc_ch482d";
+		regulator-always-on;
+		regulator-boot-on;
+	};
 };
 
 &gpio_leds {
@@ -250,6 +261,10 @@
 	reset-gpios = <&gpio0 RK_PC3 GPIO_ACTIVE_HIGH>;
 	vpcie3v3-supply = <&vcc3v3_sys>;
 	pinctrl-0 = <&pcie20m2_pins>;
+	status = "disabled";
+};
+
+&sata2 {
 	status = "disabled";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
@@ -28,18 +28,6 @@
 		};
 	};
 
-	leds {
-		compatible = "gpio-leds";
-		pinctrl-names = "default";
-		pinctrl-0 = <&led_on_off>;
-
-		led-0 {
-			gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
-			label = "green:heartbeat";
-			linux,default-trigger = "heartbeat";
-		};
-	};
-
 	vcc5v0_usb20: vcc5v0-usb20-regulator {
 		compatible = "regulator-fixed";
 		enable-active-low;
@@ -61,6 +49,21 @@
 		regulator-max-microvolt = <3300000>;
 		startup-delay-us = <100000>;
 		vin-supply = <&vcc3v3_sys>;
+	};
+};
+
+&gpio_leds {
+	board-led {
+		gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&board_led>;
+		linux,default-trigger = "heartbeat";
+	};
+
+	sata2-led {
+		gpios = <&gpio0 RK_PC2 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&sata2_led>;
+		linux,default-trigger = "disk-activity";
+		trigger-sources = <&sata2>;
 	};
 };
 
@@ -270,9 +273,10 @@
 	};
 
 	leds {
-		led_on_off: led-on-off {
+		board_led: board-led {
 			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+
 		sata2_led: sata2-led{
 			rockchip,pins = <0 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
@@ -13,6 +13,7 @@
 #include <dt-bindings/input/rk-input.h>
 #include <dt-bindings/display/drm_mipi_dsi.h>
 #include <dt-bindings/sensor-dev.h>
+#include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
 
 / {
@@ -111,11 +112,10 @@
 		compatible = "gpio-leds";
 		status = "okay";
 
-		user-led {
-			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "timer";
-			default-state = "on";
-			pinctrl-0 = <&user_led_set>;
+		sodimm-led {
+			gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&sodimm_led>;
+			linux,default-trigger = "heartbeat";
 		};
 	};
 };
@@ -701,7 +701,7 @@
 	};
 
 	leds {
-		user_led_set: user-led {
+		sodimm_led: sodimm-led {
 			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};


### PR DESCRIPTION
* Update LED definitions
* Add supporting code for SATA2/PCIe

Most of the code are taken from existing [SATA2 overlay](https://github.com/radxa/overlays/blob/0013d00e27cae60fbd48a29f78ee19f3b5c8a89f/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-sata.dts).