### PR TITLE
rk356x dts update

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
@@ -492,6 +492,10 @@
 	status = "okay";
 };
 
+&rknpu {
+	rknpu-supply = <&vdd_gpu>;
+};
+
 &saradc {
 	status = "okay";
 	vref-supply = <&vcc_1v8>;

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module.dtsi
@@ -47,20 +47,6 @@
 			<0x0 0xfd90f000 0x0 0x1000>;
 	};
 
-	reserved_memory: reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		rknpu_reserved: rknpu {
-			compatible = "shared-dma-pool";
-			inactive;
-			reusable;
-			size = <0x0 0x20000000>;
-			alignment = <0x0 0x1000>;
-		};
-	};
-
 	rk817_sound: rk817-sound {
 		status = "disabled";
 		compatible = "simple-audio-card";
@@ -553,20 +539,8 @@
 	status = "okay";
 };
 
-&bus_npu {
-	bus-supply = <&vdd_logic>;
-	pvtm-supply = <&vdd_cpu>;
-	status = "okay";
-};
-
 &rknpu {
-	memory-region = <&rknpu_reserved>;
 	rknpu-supply = <&vdd_gpu>;
-	status = "okay";
-};
-
-&rknpu_mmu {
-	status = "okay";
 };
 
 &saradc {

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
@@ -51,8 +51,8 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi";
-		status = "disabled";
+		simple-audio-card,name = "rockchip-hdmi0";
+		status = "okay";
 
 		simple-audio-card,cpu {
 			sound-dai = <&i2s0_8ch>;
@@ -84,7 +84,7 @@
 		status = "okay";
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
-		simple-audio-card,name = "rockchip,rk809-codec";
+		simple-audio-card,name = "rockchip-rk809";
 		simple-audio-card,mclk-fs = <256>;
 
 		simple-audio-card,cpu {

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
@@ -80,20 +80,6 @@
 		};
 	};
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		rknpu_reserved: rknpu {
-			compatible = "shared-dma-pool";
-			inactive;
-			reusable;
-			size = <0x0 0x08000000>;
-			alignment = <0x0 0x1000>;
-		};
-	};
-
 	rk809_sound: rk809-sound {
 		status = "okay";
 		compatible = "simple-audio-card";
@@ -758,13 +744,7 @@
 };
 
 &rknpu {
-	memory-region = <&rknpu_reserved>;
 	rknpu-supply = <&vdd_npu>;
-	status = "okay";
-};
-
-&rknpu_mmu {
-	status = "disabled";
 };
 
 &saradc {

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
@@ -18,6 +18,13 @@
 	model = "Radxa ROCK3 Model C";
 	compatible = "radxa,rock-3c", "rockchip,rk3566";
 
+	fan0: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <0 64 128 192 255>;
+		pwms = <&pwm15 0 40000 0>;
+	};
+
 	fiq_debugger: fiq-debugger {
 		compatible = "rockchip,fiq-debugger";
 		rockchip,serial-id = <2>;
@@ -213,8 +220,33 @@
 	cpu-supply = <&vdd_cpu>;
 };
 
+// Fan PWM
 &pwm15 {
+	pinctrl-names = "active";
+	pinctrl-0 = <&pwm15m0_pins>;
 	status = "okay";
+};
+
+&threshold {
+	temperature = <60000>;
+};
+
+&soc_thermal {
+	sustainable-power = <5000>; /* milliwatts */
+	cooling-maps {
+		map3 {
+			trip = <&target>;
+			cooling-device =
+				<&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+			contribution = <8192>;
+		};
+		map4 {
+			trip = <&threshold>;
+			cooling-device =
+				<&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+			contribution = <8192>;
+		};
+	};
 };
 
 &dfi {

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-rock-3-compute-module-plus.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-rock-3-compute-module-plus.dtsi
@@ -46,20 +46,6 @@
 			<0x0 0xfd90f000 0x0 0x1000>;
 	};
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		rknpu_reserved: rknpu {
-			compatible = "shared-dma-pool";
-			inactive;
-			reusable;
-			size = <0x0 0x20000000>;
-			alignment = <0x0 0x1000>;
-		};
-	};
-
 	rk809_sound: rk809-sound {
 		status = "disabled";
 		compatible = "simple-audio-card";
@@ -552,20 +538,8 @@
 	status = "okay";
 };
 
-&bus_npu {
-	bus-supply = <&vdd_logic>;
-	pvtm-supply = <&vdd_cpu>;
-	status = "okay";
-};
-
 &rknpu {
-	memory-region = <&rknpu_reserved>;
 	rknpu-supply = <&vdd_npu>;
-	status = "okay";
-};
-
-&rknpu_mmu {
-	status = "okay";
 };
 
 &saradc {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -99,20 +99,6 @@
 		};
 	};
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		rknpu_reserved: rknpu {
-			compatible = "shared-dma-pool";
-			inactive;
-			reusable;
-			size = <0x0 0x20000000>;
-			alignment = <0x0 0x1000>;
-		};
-	};
-
 	rk809_sound: rk809-sound {
 		status = "okay";
 		compatible = "simple-audio-card";
@@ -714,20 +700,8 @@
 	status = "okay";
 };
 
-&bus_npu {
-	bus-supply = <&vdd_logic>;
-	pvtm-supply = <&vdd_cpu>;
-	status = "okay";
-};
-
 &rknpu {
-	memory-region = <&rknpu_reserved>;
 	rknpu-supply = <&vdd_npu>;
-	status = "okay";
-};
-
-&rknpu_mmu {
-	status = "okay";
 };
 
 &saradc {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
@@ -93,20 +93,6 @@
 		};
 	};
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		rknpu_reserved: rknpu {
-			compatible = "shared-dma-pool";
-			inactive;
-			reusable;
-			size = <0x0 0x20000000>;
-			alignment = <0x0 0x1000>;
-		};
-	};
-
 	rk809_sound: rk809-sound {
 		status = "okay";
 		compatible = "simple-audio-card";
@@ -745,20 +731,8 @@
 	status = "okay";
 };
 
-&bus_npu {
-	bus-supply = <&vdd_logic>;
-	pvtm-supply = <&vdd_cpu>;
-	status = "okay";
-};
-
 &rknpu {
-	memory-region = <&rknpu_reserved>;
 	rknpu-supply = <&vdd_npu>;
-	status = "okay";
-};
-
-&rknpu_mmu {
-	status = "okay";
 };
 
 &saradc {

--- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
@@ -1178,7 +1178,7 @@
 		};
 		opp-900000000 {
 			opp-hz = /bits/ 64 <900000000>;
-			opp-microvolt = <0>;
+			opp-microvolt = <925000>;
 		};
 	};
 
@@ -1475,7 +1475,7 @@
 
 		opp-297000000 {
 			opp-hz = /bits/ 64 <297000000>;
-			opp-microvolt = <0>;
+			opp-microvolt = <925000>;
 		};
 		opp-400000000 {
 			opp-hz = /bits/ 64 <400000000>;


### PR DESCRIPTION
* Provide a sane voltage for OPP (fixes ThomasKaiser/sbc-bench#62)
* Disable NPU across our products so a single overlay could be used across them
* 2 more patches from [`bsp`](https://github.com/radxa-repo/bsp/tree/d9705b69b22fdbcd798737834d316a37d88abe1c/linux/rk356x/0020-rock-3c), since the NPU change created conflicts with existing patch