### PR TITLE
arm64: dts: rk356x: enable fiq_debugger at board level

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -66,6 +66,10 @@
 	};
 };
 
+&fiq_debugger {
+	status = "okay";
+};
+
 &gpio_leds {
 	pi-led-green {
 		gpios = <&gpio4 4 GPIO_ACTIVE_LOW>;

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -39,6 +39,10 @@
 
 };
 
+&fiq_debugger {
+	status = "okay";
+};
+
 &i2s0_8ch {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
@@ -78,6 +78,10 @@
 	};
 };
 
+&fiq_debugger {
+	status = "okay";
+};
+
 &gpio0 {
 	gpio-line-names =
 		/* GPIO0_A0-A3 */

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-e23.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-e23.dts
@@ -56,6 +56,10 @@
 	};
 };
 
+&fiq_debugger {
+	status = "okay";
+};
+
 &pwm0 {
 	pinctrl-0 = <&pwm0m1_pins>;
 	status = "okay";

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module-sodimm.dtsi
@@ -29,7 +29,7 @@
 		interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL_LOW>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&uart2m0_xfer>;
-		status = "okay";
+		status = "disabled";
 	};
 
 	debug: debug@fd904000 {

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
@@ -102,6 +102,7 @@
 
 &fiq_debugger {
 	rockchip,baudrate = <115200>;
+	status = "okay";
 };
 
 &sdio_pwrseq {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -23,7 +23,7 @@
 		interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL_LOW>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&uart2m0_xfer>;
-		status = "disabled";
+		status = "okay";
 	};
 
 	debug: debug@fd904000 {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
@@ -25,7 +25,7 @@
 		interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL_LOW>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&uart2m0_xfer>;
-		status = "disabled";
+		status = "okay";
 	};
 
 	debug: debug@fd904000 {


### PR DESCRIPTION
Currently radxa/overlays assumes fiq_debugger is default on at UART2. Enable them across our products.