### PR TITLE
net: smsc95xx: persistent MAC address from serial

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -32,6 +32,10 @@
 #include <linux/of_net.h>
 #include "smsc95xx.h"
 
+#if defined(__arm64__) || defined(__aarch64__)
+#include <asm/system_info.h>
+#endif
+
 #define SMSC_CHIPNAME			"smsc95xx"
 #define SMSC_DRIVER_VERSION		"1.0.6"
 #define HS_USB_PKT_SIZE			(512)
@@ -989,6 +993,23 @@ static void smsc95xx_init_mac_address(struct usbnet *dev)
 	/* Check module parameters */
 	if (smsc95xx_is_macaddr_param(dev, dev->net->dev_addr))
 		return;
+
+#if defined(__arm64__) || defined(__aarch64__)
+	/* Generate a MAC address from system serial */
+	if (system_serial_low != 0 && system_serial_high != 0) {
+		*((u32 *) &dev->net->dev_addr[MAC_ADDR_LEN - sizeof(u32)]) =
+			crc32(system_serial_high, &system_serial_low, sizeof(system_serial_low));
+		// Prefix with Microchip Technology Inc's vendor ID
+		dev->net->dev_addr[0] = 0;
+		dev->net->dev_addr[1] = 4;
+		dev->net->dev_addr[2] = 0xa3;
+		netif_dbg(dev, ifup, dev->net, "Generate MAC address from CPU serial: "
+			"%02x:%02x:%02x:%02x:%02x:%02x\n",
+				dev->net->dev_addr[0], dev->net->dev_addr[1], dev->net->dev_addr[2],
+				dev->net->dev_addr[3], dev->net->dev_addr[4], dev->net->dev_addr[5]);
+		return;
+	}
+#endif
 
 	/* no useful static MAC address found. generate a random one */
 	eth_hw_addr_random(dev->net);


### PR DESCRIPTION
This provides a persistent MAC address for CM3S IO.