### PR TITLE
arm64: dts: radxa cm3 io: delete unreferenced ch482d pins

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -255,18 +255,6 @@
 		};
 	};
 
-	ch482d {
-		//usb3.0 --> sata1
-		ch482d_en1: ch482d-en1 {
-			rockchip,pins = <3 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-
-		//pcie2.0 --> sata2
-		ch482d_en2: ch482d-en2 {
-			rockchip,pins = <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
 	gmac1 {
 		gmac1m0_miim: gmac1m0-miim {
 			rockchip,pins =


### PR DESCRIPTION
These pins are used in SATA overlays to toggle switches, so the signal can be routed to different connectors.

However, when no overlays are specified, those pins are still held by pinctrl, thus unavailable for other usage.

Remove them from here and redefine them in overlays: https://github.com/radxa/overlays/commit/df0a1baad774fc7cacfeb03111c230c129207f2a