### PR TITLE
arm64: dts: rock-5a: fix avdd_0v75_s0 suspend voltage

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -741,7 +741,7 @@
 &avdd_0v75_s0 {
 	regulator-state-mem {
 		regulator-on-in-suspend;
-		regulator-min-microvolt = <837500>;
+		regulator-suspend-microvolt = <837500>;
 	};
 };
 


### PR DESCRIPTION
This looks like a typo considering the rest of the suspend voltage assignments.

Waiting for @vamrs-feng 's confirmation.