### PR TITLE
Update ROCK 4 features

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -807,10 +807,6 @@
 	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
 };
 
-&uart2 {
-	status = "okay";
-};
-
 &usb_host0_ehci {
 	status = "okay";
 };

--- a/drivers/mtd/spi-nor/xtx.c
+++ b/drivers/mtd/spi-nor/xtx.c
@@ -8,6 +8,8 @@
 #include "core.h"
 
 static const struct flash_info xtx_parts[] = {
+	{ "XT25F32B", INFO(0x0b4016, 0, 64 * 1024, 64,
+			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
 	{ "XT25F64F", INFO(0x0b4017, 0, 64 * 1024, 128,
 			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
 	{ "XT25F128B", INFO(0x0b4018, 0, 64 * 1024, 256,


### PR DESCRIPTION
* Disable UART2 since FIQ Debugger is already enabled.
* Add SPI flash info for XT25F32B, which is used on ROCK 4.