### PR TITLE
CM3 bug fixes

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -95,11 +95,12 @@
 	cap-mmc-highspeed;
 	cap-sd-highspeed;
 	disable-wp;
+	broken-cd;
 	sd-uhs-sdr104;
 	vmmc-supply = <&vcc_sd>;
 	vqmmc-supply = <&vccio_sd>;
 	pinctrl-names = "default";
-	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd>;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-rock-3-compute-module.dtsi
@@ -579,7 +579,7 @@
 		compatible = "brcm,bcm4329-fmac";
 		reg = <1>;
 		interrupt-parent = <&gpio2>;
-		interrupts = <RK_PC1 GPIO_ACTIVE_HIGH>;
+		interrupts = <RK_PC1 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-names = "host-wake";
 		pinctrl-names = "default";
 		pinctrl-0 = <&wifi_host_wake_l>;


### PR DESCRIPTION
1. On Raspberry Pi CM4 IO, the card detection pin is not connected. Need to specify broken-cd and remove cd pin to force system to poll the device.
2. Fix high CPU usage triggered by incorrect interrupt definition.