### PR TITLE
arm64: dts: rk3588: set sdhci to HS200

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -487,12 +487,9 @@
 
 &sdhci {
 	bus-width = <8>;
-	no-sdio;
-	no-sd;
 	non-removable;
-	max-frequency = <200000000>;
-	mmc-hs400-1_8v;
-	//mmc-hs400-enhanced-strobe;
+	max-frequency = <150000000>;
+	mmc-hs200-1_8v;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5-io.dts
@@ -300,12 +300,6 @@
 };
 
 &sdhci {
-	bus-width = <8>;
-	no-sdio;
-	no-sd;
-	non-removable;
-	max-frequency = <150000000>;
-	mmc-hs400-1_8v;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
@@ -248,6 +248,13 @@
 	status = "okay";
 };
 
+&sdhci {
+	bus-width = <8>;
+	non-removable;
+	max-frequency = <150000000>;
+	mmc-hs200-1_8v;
+};
+
 &mdio1 {
 	rgmii_phy1: phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c22";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
@@ -148,6 +148,10 @@
 	status = "okay";
 };
 
+&sdhci {
+	status = "okay";
+};
+
 &hdmi0 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
@@ -281,12 +281,9 @@
 
 &sdhci {
 	bus-width = <8>;
-	no-sdio;
-	no-sd;
 	non-removable;
-	max-frequency = <200000000>;
-	mmc-hs400-1_8v;
-	status = "okay";
+	max-frequency = <150000000>;
+	mmc-hs200-1_8v;
 };
 
 &mdio1 {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -405,12 +405,9 @@
 
 &sdhci {
 	bus-width = <8>;
-	no-sdio;
-	no-sd;
 	non-removable;
-	max-frequency = <200000000>;
-	mmc-hs400-1_8v;
-	/delete-property/ mmc-hs400-enhanced-strobe;
+	max-frequency = <150000000>;
+	mmc-hs200-1_8v;
 	pinctrl-names = "default";
 	pinctrl-0 = <&emmc_rstnout &emmc_bus8 &emmc_clk &emmc_cmd &emmc_data_strobe>;
 	status = "okay";


### PR DESCRIPTION
This fixes some compatibility issues when using Foresee eMMC.

Related forum post: https://forum.radxa.com/t/5a-corrupts-emmc-was-5a-does-not-boot/16930/32