### PR TITLE
arm64: dts: rk356x: use consistent name for HDMI sound

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -50,7 +50,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi";
+		simple-audio-card,name = "rockchip-hdmi0";
 
 		simple-audio-card,cpu {
 				sound-dai = <&i2s0_8ch>;

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -27,7 +27,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi";
+		simple-audio-card,name = "rockchip-hdmi0";
 
 		simple-audio-card,cpu {
 				sound-dai = <&i2s0_8ch>;

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -70,7 +70,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi";
+		simple-audio-card,name = "rockchip-hdmi0";
 		status = "okay";
 
 		simple-audio-card,cpu {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3b.dts
@@ -67,7 +67,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi";
+		simple-audio-card,name = "rockchip-hdmi0";
 		status = "okay";
 
 		simple-audio-card,cpu {


### PR DESCRIPTION
tested on cm3-io and rock 3a