### PR TITLE
arm64: dts: restore cm3-sodimm dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -126,6 +126,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-rk817-tablet-rkg11.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-rk817-tablet-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-ddr4-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-rock-3c.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3-sodimm-io.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3s-io.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-ddr4-v10-dual-camera.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-ddr4-v10-linux.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-sodimm-io.dts
@@ -1,0 +1,1 @@
+rk3566-radxa-cm3s-io.dts


### PR DESCRIPTION
This is needed to maintain compatibility with existing bootloaders.