### PR TITLE
drm/rockchip: vop: check mode_valid by total pixels

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
@@ -2755,8 +2755,8 @@ vop_crtc_mode_valid(struct drm_crtc *crtc, const struct drm_display_mode *mode)
 	int request_clock = mode->clock;
 	int clock;
 
-	if (mode->hdisplay > vop_data->max_output.width)
-		return MODE_BAD_HVALUE;
+	if (mode->hdisplay * mode->vdisplay > vop_data->max_output.width * vop_data->max_output.height)
+		return MODE_BAD;
 
 	if ((mode->flags & DRM_MODE_FLAG_INTERLACE) &&
 	    VOP_MAJOR(vop->version) == 3 &&

--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -3133,11 +3133,8 @@ vop2_wb_connector_mode_valid(struct drm_connector *connector,
 	h = mode->vdisplay;
 
 
-	if (w > vop2->data->wb->max_output.width)
-		return MODE_BAD_HVALUE;
-
-	if (h > vop2->data->wb->max_output.height)
-		return MODE_BAD_VVALUE;
+	if (w * h > vop2->data->wb->max_output.width * vop2->data->wb->max_output.height)
+		return MODE_BAD;
 
 	return MODE_OK;
 }


### PR DESCRIPTION
Currently the function will reject vertical displays. Changed to test total pixels instead.

This has not been tested on real hardware.