### PR TITLE
drivers: phy: rockchip: Fix the suspend problem caused by the driver

### DIFF
--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
@@ -3025,7 +3025,8 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 
 		/* activate the linestate to detect the next interrupt. */
 		mutex_lock(&rport->mutex);
-		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
+		if (rport->port_id == USB2PHY_PORT_OTG)
+			ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
 		mutex_unlock(&rport->mutex);
 		if (ret) {
 			dev_err(rphy->dev, "failed to enable linestate irq\n");


### PR DESCRIPTION
u2phy0_host linestate irq state has been cleared before, no need to clear it again.