### PR TITLE
Fix rock 3c/cm3s io USB wakeup problem

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3s-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3s-io.dts
@@ -255,8 +255,7 @@
 };
 
 &u2phy0_host {
-	phy-supply = <&vcc5v0_usb20>;
-	status = "okay";
+	status = "disabled";
 };
 
 &combphy2_psq {

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3s.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3s.dtsi
@@ -574,6 +574,7 @@
 };
 
 &u2phy0_host {
+	disable_wakeup;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dts
@@ -885,6 +885,7 @@
 
 &u2phy0_host {
 	phy-supply = <&vcc5v0_host>;
+	disable_wakeup;
 	status = "okay";
 };
 

--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
@@ -300,6 +300,7 @@ struct rockchip_usb2phy_port {
 	struct wake_lock	wakelock;
 	enum usb_otg_state	state;
 	enum usb_dr_mode	mode;
+	bool 			disable_wakeup;
 };
 
 /**
@@ -2377,6 +2378,7 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
 		}
 
 		rport->phy = phy;
+		rport->disable_wakeup = of_property_read_bool(child_np, "disable_wakeup");
 		phy_set_drvdata(rport->phy, rport);
 
 		/* initialize otg/host port separately */
@@ -3025,7 +3027,8 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 
 		/* activate the linestate to detect the next interrupt. */
 		mutex_lock(&rport->mutex);
-		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
+		// Only enable interrupt during suspend if no disable_wakeup was defined
+		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, !rport->disable_wakeup);
 		mutex_unlock(&rport->mutex);
 		if (ret) {
 			dev_err(rphy->dev, "failed to enable linestate irq\n");

--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
@@ -3025,8 +3025,7 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 
 		/* activate the linestate to detect the next interrupt. */
 		mutex_lock(&rport->mutex);
-		if (rport->port_id == USB2PHY_PORT_OTG)
-			ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
+		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
 		mutex_unlock(&rport->mutex);
 		if (ret) {
 			dev_err(rphy->dev, "failed to enable linestate irq\n");


### PR DESCRIPTION
The current rock 3c/ cm3s io has the problem that some usb ports wake up automatically 
after the system is suspended. It is necessary to temporarily disable the wake-up function 
of a certain USB port, or not use the problematic USB port.