### PR TITLE
arm64: dts: rock4: fix Fast Ethernet packet drops

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -243,8 +243,8 @@
 	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
 	snps,reset-active-low;
 	snps,reset-delays-us = <0 10000 50000>;
-	tx_delay = <0x28>;
-	rx_delay = <0x11>;
+	tx_delay = <0x2a>;
+	rx_delay = <0x21>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Issus was described in https://forum.radxa.com/t/rock-4a-slow-link-speed-on-100mbit-network/17760/2. However, those values were what we use on Liwan and they were provided by Realtek.

Waiting for user feedback.