### PR TITLE
Revert "FROMGIT: usb: dwc3: core: Do not perform GCTL_CORE_SOFTRESET …

### DIFF
--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -169,13 +169,9 @@ static void __dwc3_set_mode(struct work_struct *work)
 		break;
 	}
 
-	/*
-	 * When current_dr_role is not set, there's no role switching.
-	 * Only perform GCTL.CoreSoftReset when there's DRD role switching.
-	 */
-	if (dwc->current_dr_role && ((DWC3_IP_IS(DWC3) ||
-			DWC3_VER_IS_PRIOR(DWC31, 190A)) &&
-			dwc->desired_dr_role != DWC3_GCTL_PRTCAP_OTG)) {
+	/* For DRD host or device mode only */
+	if ((DWC3_IP_IS(DWC3) || DWC3_VER_IS_PRIOR(DWC31, 190A)) &&
+	    dwc->desired_dr_role != DWC3_GCTL_PRTCAP_OTG) {
 		reg = dwc3_readl(dwc->regs, DWC3_GCTL);
 		reg |= DWC3_GCTL_CORESOFTRESET;
 		dwc3_writel(dwc->regs, DWC3_GCTL, reg);


### PR DESCRIPTION
…during bootup"

This reverts commit c301d142e8072f1a487bc37bb8d4bb3102ac41e9.

This commit causes the OTG port always working as device after boot regardless of the status of OTG physical switch.

Rockchip Redmine: https://redmine.rock-chips.com/issues/429397