### PR TITLE
arm64: dts: rockchip: radxa cm3 rpi cm4: Do not use polling detection

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -95,7 +95,6 @@
 	cap-mmc-highspeed;
 	cap-sd-highspeed;
 	disable-wp;
-	broken-cd;
 	sd-uhs-sdr104;
 	vmmc-supply = <&vcc_sd>;
 	vqmmc-supply = <&vccio_sd>;


### PR DESCRIPTION
解决单独 emmc 启动会有如下报错问题:

dwmmc_rockchip fe2b0000.dwmmc: failed to enable vmmc regulator
dwmmc_rockchip fe2b0000.dwmmc: could not set regulator OCR (-22)
