### PR TITLE
cm3/cm3 io: open dmc by default, close hardware cursor

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -8,7 +8,6 @@
 /dts-v1/;
 
 #include "rk3566-radxa-cm3.dtsi"
-#include <dt-bindings/display/rockchip_vop.h>
 
 / {
 	model = "Radxa Compute Module 3(CM3) IO Board";
@@ -106,14 +105,6 @@
 &route_hdmi {
 	status = "okay";
 	connect = <&vp0_out_hdmi>;
-};
-
-&vp0 {
-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER0>;
-};
-
-&vp1 {
-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER1>;
 };
 
 &sdmmc0 {

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
@@ -80,7 +80,7 @@
 
 &dmc {
 	center-supply = <&vdd_logic>;
-	status = "disabled";
+	status = "okay";
 };
 
 &rkcif {


### PR DESCRIPTION
1. The dynamic frequency modulation function is enabled by default
2. Enable hardware cursor causes the serial port terminal to output error logs, there is 
no obvious impact after disabling, and this function will not be added for the time being;