### PR TITLE
    mmc: sdhci-of-dwcmshc: improve HS400ES compatibility for some eMM…

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -406,7 +406,9 @@
 &sdhci {
 	bus-width = <8>;
 	non-removable;
-	max-frequency = <150000000>;
+	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
 	mmc-hs200-1_8v;
 	status = "okay";
 };


### PR DESCRIPTION
…C devices

    There is a compatibility problem between the RK3588 and some eMMC devices
    with HS400ES mode.