### PR TITLE
arm: dts: radxa cm3 rpi cm4 io: fix the issue that an error occurred …

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -21,6 +21,7 @@
 		pinctrl-0 = <&sdmmc_pwren>;
 		regulator-name = "vcc_sd";
 		regulator-always-on;
+		vin-supply = <&vcc3v3_sys>;
 	};
 
 	hdmi_sound: hdmi-sound {


### PR DESCRIPTION
修复 emmc 启动报错问题:
[  300.402412] dwmmc_rockchip fe2b0000.dwmmc: failed to enable vmmc regulator
[  300.446168] dwmmc_rockchip fe2b0000.dwmmc: could not set regulator OCR (-22)


