### PR TITLE
Radxa CM3 Rpi CM4 IO: Fixed sd card hot swap error

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -97,6 +97,7 @@
 	cap-sd-highspeed;
 	disable-wp;
 	broken-cd;
+	non-removable;
 	sd-uhs-sdr104;
 	vmmc-supply = <&vcc_sd>;
 	vqmmc-supply = <&vccio_sd>;


### PR DESCRIPTION
the error log:
   [   29.491324] mmc0: delay init for 600 ms to enable UHS mode
   [   30.028589] mmc_host mmc0: Timeout sending command (cmd 0x10202000 arg 0x0 status 0x90202000)
   [   31.112194] mmc0: tuning execution failed: -5