### PR TITLE
rock 4se/4c+ : Limit the working frequency of sdio

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
@@ -277,6 +277,7 @@
 	#size-cells = <0>;
 	bus-width = <4>;
 	clock-frequency = <50000000>;
+	max-frequency = <100000000>;
 	cap-sdio-irq;
 	cap-sd-highspeed;
 	keep-power-in-suspend;

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
@@ -44,6 +44,7 @@
 
 &sdio0 {
 	status = "okay";
+	max-frequency = <100000000>;
 
 	brcmf: wifi@1 {
 		compatible = "brcm,bcm4329-fmac";


### PR DESCRIPTION
If the working frequency of sdio is too high, it may cause 
the cm256 wifi module connected under it to cut off