### PR TITLE
FROMLIST: pwm: gpio: Add a generic gpio based PWM driver

### DIFF
--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -181,6 +181,21 @@ config PWM_FSL_FTM
 	  To compile this driver as a module, choose M here: the module
 	  will be called pwm-fsl-ftm.
 
+config PWM_GPIO
+	tristate "Generic GPIO bit-banged PWM driver"
+	depends on OF
+	depends on GPIOLIB
+	help
+	  Some platforms do not offer any hardware PWM capabilities but do have
+	  General Purpose Input Output (GPIO) pins available. Using the kernels
+	  High-Resolution Timer API this driver tries to toggle GPIO using the
+	  generic kernel PWM framework. The maximum frequency and/or accuracy
+	  is dependent on several factors such as system load and the maximum
+	  speed a pin can be toggled at the hardware.
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called pwm-gpio.
+
 config PWM_HIBVT
 	tristate "HiSilicon BVT PWM support"
 	depends on ARCH_HISI || COMPILE_TEST

--- a/drivers/pwm/Makefile
+++ b/drivers/pwm/Makefile
@@ -15,6 +15,7 @@ obj-$(CONFIG_PWM_CRC)		+= pwm-crc.o
 obj-$(CONFIG_PWM_CROS_EC)	+= pwm-cros-ec.o
 obj-$(CONFIG_PWM_EP93XX)	+= pwm-ep93xx.o
 obj-$(CONFIG_PWM_FSL_FTM)	+= pwm-fsl-ftm.o
+obj-$(CONFIG_PWM_GPIO)		+= pwm-gpio.o
 obj-$(CONFIG_PWM_HIBVT)		+= pwm-hibvt.o
 obj-$(CONFIG_PWM_IMG)		+= pwm-img.o
 obj-$(CONFIG_PWM_IMX1)		+= pwm-imx1.o

--- a/drivers/pwm/pwm-gpio.c
+++ b/drivers/pwm/pwm-gpio.c
@@ -157,7 +157,6 @@ static int gpio_pwm_probe(struct platform_device *pdev)
 	pc->chip.npwm = 1;
 	pc->chip.of_xlate = of_pwm_xlate_with_flags;
 	pc->chip.of_pwm_n_cells = 3;
-	pc->chip.can_sleep = true;
 
 	pc->gpiod = devm_gpiod_get(&pdev->dev, "pwm", GPIOD_OUT_LOW);
 


### PR DESCRIPTION
This patch adds a bit-banging gpio PWM driver. It makes use of hrtimers, to allow nano-second resolution, though it obviously strongly depends on the switching speed of the gpio pins, hrtimer and system load.

Each pwm node can have 1 or more "pwm-gpio" entries, which will be treated as pwm's as part of a pwm chip.

Link: https://patchwork.ozlabs.org/project/linux-pwm/patch/1445895161-2317-8-git-send-email-o.schinagl@ultimaker.com/


Change-Id: Ibdb28eca3239a3a8503c947667117a9b0e9427b9

---

Cherry-picked from 31e2803cc935b32d65f9a1da3dffc54ef19cae1d. For some reason PWM_GPIO was missing from Kconfig despite the driver was included.