### PR TITLE
nx5 io: enable usb wakeup, fix otg function failure problem

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
@@ -184,6 +184,10 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
+	phys = <&u2phy0_otg>;
+	phy-names = "usb2-phy";
+	maximum-speed = "high-speed";
+	extcon = <&u2phy0>;
 	dr_mode = "host";
 };
 
@@ -193,10 +197,6 @@
 };
 
 &usbdp_phy0_dp {
-	status = "okay";
-};
-
-&usbdp_phy0_u3 {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
@@ -82,7 +82,7 @@
 		pinctrl-0 = <&led1_en>;
 		pinctrl-names = "default";
 		state_led {
-			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "heartbeat";
 			default-state = "on";
 		};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
@@ -340,6 +340,65 @@
 	};
 };
 
+&rockchip_suspend {
+	compatible = "rockchip,pm-rk3588";
+	status = "okay";
+	rockchip,sleep-debug-en = <1>;
+	rockchip,sleep-mode-config = <
+		(0
+		| RKPM_SLP_ARMOFF_DDRPD
+		)
+	>;
+	rockchip,wakeup-config = <
+		(0
+		| RKPM_GPIO_WKUP_EN
+		| RKPM_USB_WKUP_EN
+		)
+	>;
+};
+
+&avdd_0v75_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <837500>;
+	};
+};
+
+&avcc_1v8_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <1800000>;
+	};
+};
+
+&vcc_1v8_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <1800000>;
+	};
+};
+
+&vcc_3v3_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <3300000>;
+	};
+};
+
+&vdd_log_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <750000>;
+	};
+};
+
+&vdd_ddr_pll_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+		regulator-suspend-microvolt = <850000>;
+	};
+};
+
 &pinctrl {
 
 	hym8563 {


### PR DESCRIPTION
1. enable usb wakeup
2. The usbdrd_dwc3_0 controller needs to remove the reference 
    to usbdp_phy0_u3 because all lanes are used by dp.