### PR TITLE
drivers/net: stmmac: use phy uid for rtl8211f fixup function

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -57,8 +57,8 @@
 #define	STMMAC_ALIGN(x)		ALIGN(ALIGN(x, SMP_CACHE_BYTES), 16)
 #define	TSO_MAX_BUFF_SIZE	(SZ_16K - 1)
 
-#define	RTL8211F_PHY_ID		0x001cc916
-#define	RTL8211F_PHY_ID_MASK	0x001fffff
+#define	RTL8211F_PHY_UID	0x001cc800
+#define	RTL8211F_PHY_UID_MASK	0x001ffc00
 #define	RTL8211F_PAGE_SELECT	0x1f
 #define	RTL8211F_LCR_ADDR	0x10
 #define	RTL8211F_EEELCR_ADDR	0x11
@@ -5264,13 +5264,13 @@ int stmmac_dvr_probe(struct device *device,
 	pm_runtime_put(device);
 
 	/* Register fixup for PHY RTL8211F */
-	ret = phy_register_fixup_for_uid(RTL8211F_PHY_ID, RTL8211F_PHY_ID_MASK, phy_rtl8211f_led_fixup);
+	ret = phy_register_fixup_for_uid(RTL8211F_PHY_UID, RTL8211F_PHY_UID_MASK, phy_rtl8211f_led_fixup);
 	if (ret) {
 		dev_warn(priv->device, "Failed to register fixup for PHY RTL8211F.\n");
 	}
 
 	/* Register fixup for PHY RTL8211F disabling EEE */
-	ret = phy_register_fixup_for_uid(RTL8211F_PHY_ID, RTL8211F_PHY_ID_MASK, phy_rtl8211f_eee_fixup);
+	ret = phy_register_fixup_for_uid(RTL8211F_PHY_UID, RTL8211F_PHY_UID_MASK, phy_rtl8211f_eee_fixup);
 	if (ret) {
 		dev_warn(priv->device, "Failed to register fixup for PHY RTL8211F disabling EEE.\n");
 	}


### PR DESCRIPTION
For RTL8211f, phyid is different for chips manufactured by different fabs, but phy_uid is fixed. 
Use phy_uid to match the repair function;