### PR TITLE
arm64: dts: rock 4c+: remove unused i2s1

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
@@ -336,11 +336,6 @@
 	pinctrl-0 = <&i2s0_8ch_bus>;
 };
 
-&i2s1 {
-	status = "okay";
-	#sound-dai-cells = <0>;
-};
-
 &i2s2 {
 	status = "okay";
 	dmas = <&dmac_bus 4>;

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -532,12 +532,6 @@
 	pinctrl-0 = <&i2s0_8ch_bus>;
 };
 
-&i2s1 {
-	rockchip,playback-channels = <2>;
-	rockchip,capture-channels = <2>;
-	status = "okay";
-};
-
 &i2s2 {
 	#sound-dai-cells = <0>;
 	status = "okay";


### PR DESCRIPTION
i2s1 在板级 dts 里没有被用到