### PR TITLE
rga3: fix rga3 uncompact detection

### DIFF
--- a/drivers/video/rockchip/rga3/rga3_reg_info.c
+++ b/drivers/video/rockchip/rga3/rga3_reg_info.c
@@ -331,7 +331,7 @@ static void RGA3_set_reg_win0_info(u8 *base, struct rga3_req *msg)
 		 (s_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT(1)));
 
 	/* Only on raster mode, yuv 10bit can change to compact or set endian */
-	if (msg->win0.rd_mode == RGA_RASTER_MODE && yuv10 == 1) {
+	if (msg->win0.rd_mode == 0 && yuv10 == 1) {
 		reg =
 			((reg & (~m_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT)) |
 			 (s_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT
@@ -703,7 +703,7 @@ static void RGA3_set_reg_win1_info(u8 *base, struct rga3_req *msg)
 		 (s_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT(1)));
 
 	/* Only on roster mode, yuv 10bit can change to compact or set endian */
-	if (msg->win1.rd_mode == RGA_RASTER_MODE && yuv10 == 1) {
+	if (msg->win1.rd_mode == 0 && yuv10 == 1) {
 		reg =
 			((reg & (~m_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT)) |
 			 (s_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT


### PR DESCRIPTION
RGA3 has uncompact mode to convert/scale to plane format P010 which is very well accepted HDR format.

There is a bug in vendor kernel to pass this (uncompact 10bit) configuration to the rga3 hardware registers. This patch fixes the problem.

Tested by me and @nyanmisaka.

Also it is better to merge this to rkr3.4 branch where there is an auto build system of debos kernel, do you need another PR for it?

Details are here: https://github.com/airockchip/librga/issues/45