### PR TITLE
drivers/rtc: rk808: disable when there is a preferred onboard RTC

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -200,6 +200,12 @@
 	};
 };
 
+&rk817 {
+	rtc {
+		status = "disabled";
+	};
+};
+
 &soc_thermal {
 	sustainable-power = <5000>; /* milliwatts */
 	cooling-maps {

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
@@ -272,6 +272,12 @@
 	};
 };
 
+&rk809 {
+	rtc {
+		status = "disabled";
+	};
+};
+
 &uart5 {
 	status = "okay";
 	pinctrl-names = "default";

--- a/drivers/rtc/rtc-hym8563.c
+++ b/drivers/rtc/rtc-hym8563.c
@@ -477,7 +477,7 @@ static int hym8563_init_device(struct i2c_client *client)
 	/* Clear stop flag if present */
 	ret = i2c_smbus_write_byte_data(client, HYM8563_CTL1, 0);
 	if (ret < 0)
-		return ret;
+		return -EPROBE_DEFER;
 
 	ret = i2c_smbus_read_byte_data(client, HYM8563_CTL2);
 	if (ret < 0)

--- a/drivers/rtc/rtc-rk808.c
+++ b/drivers/rtc/rtc-rk808.c
@@ -411,6 +411,7 @@ static int rk808_rtc_probe(struct platform_device *pdev)
 	case RK805_ID:
 	case RK808_ID:
 	case RK816_ID:
+	case RK817_ID:
 	case RK818_ID:
 		np = of_get_child_by_name(pdev->dev.parent->of_node, "rtc");
 		if (np && !of_device_is_available(np)) {

--- a/drivers/rtc/rtc-rk808.c
+++ b/drivers/rtc/rtc-rk808.c
@@ -410,6 +410,7 @@ static int rk808_rtc_probe(struct platform_device *pdev)
 	switch (rk808->variant) {
 	case RK805_ID:
 	case RK808_ID:
+	case RK809_ID:
 	case RK816_ID:
 	case RK817_ID:
 	case RK818_ID:


### PR DESCRIPTION
If the device is not ready, the initialization may fail. A mechanism for multiple delayed retries is added.