### PR TITLE
arm64: dts: nx5 io: fix usb2.0 otg suspend

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-io.dts
@@ -189,6 +189,8 @@
 	maximum-speed = "high-speed";
 	extcon = <&u2phy0>;
 	dr_mode = "host";
+	/* Fix usb suspend failure */
+	snps,dis_u3_susphy_quirk;
 };
 
 &usbdp_phy0 {


### PR DESCRIPTION
Solve the problem of usbdrd_dwc3_0 controller suspend execution failure when the system is sleeping.