### PR TITLE
arm64: dts: rock 5b: Resolved the issue of PD negotiation failure

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -855,8 +855,7 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
-	dr_mode = "otg";
-	usb-role-switch;
+	dr_mode = "peripheral";
 	port {
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
usb-role-switch cannot be configured when set to host or peripheral mode.