### PR TITLE
arm64: dts: radxa e25: add ADC key as macro button

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
@@ -116,6 +116,21 @@
 			max-brightness = <255>;
 		};
 	};
+
+	adc_keys: adc-keys {
+		status = "okay";
+		compatible = "adc-keys";
+		io-channels = <&saradc 0>;
+		io-channel-names = "buttons";
+		keyup-threshold-microvolt = <1800000>;
+		poll-interval = <100>;
+
+		user-key {
+			label = "macro";
+			linux,code = <KEY_MACRO>;
+			press-threshold-microvolt = <1750>;
+		};
+	};
 };
 
 &pwm1 {


### PR DESCRIPTION
Locally verified that the system can enter power off sequence by pressing the button.