### PR TITLE
fix rock5itx rtc detect failure

### DIFF
--- a/drivers/rtc/rtc-hym8563.c
+++ b/drivers/rtc/rtc-hym8563.c
@@ -558,7 +558,7 @@ static int hym8563_probe(struct i2c_client *client,
 	ret = hym8563_init_device(client);
 	if (ret) {
 		dev_err(&client->dev, "could not init device, %d\n", ret);
-		return ret;
+		return -EPROBE_DEFER;
 	}
 
 	if (client->irq > 0) {


### PR DESCRIPTION
rtc: hym8563: Solve the problem of probabilistic initialization failure of hym8563