### PR TITLE
arm64: dts: rockchip: rock 2f: add usb otg port

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3528-rock-2f.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3528-rock-2f.dts
@@ -442,6 +442,21 @@
 	status = "okay";
 };
 
+&usbdrd30 {
+	status = "okay";
+};
+
+&usbdrd_dwc3 {
+	dr_mode = "otg";
+	extcon = <&usb2phy>;
+	phys = <&u2phy_otg>;
+	phy-names = "usb2-phy";
+	maximum-speed = "high-speed";
+	snps,dis_u2_susphy_quirk;
+	snps,usb2-lpm-disable;
+	status = "okay";
+};
+
 &pinctrl {
 	usb {
 		vcc5v0_host_en: vcc5v0-host-en {


### PR DESCRIPTION
arm64: dts: rockchip: rock 2f: add usb otg port

Signed-off-by: SongJun Li <lisongjun@radxa.com>