### PR TITLE
Adds PCIe Switch support for rk3399

### DIFF
--- a/arch/arm64/include/asm/assembler.h
+++ b/arch/arm64/include/asm/assembler.h
@@ -58,6 +58,15 @@
 /*
  * Save/restore interrupts.
  */
+
+	.macro  disable_irq
+	msr     daifset, #2
+	.endm
+
+	.macro  enable_irq
+	msr     daifclr, #2
+	.endm
+
 	.macro	save_and_disable_irq, flags
 	mrs	\flags, daif
 	msr	daifset, #2

--- a/arch/arm64/include/asm/exception.h
+++ b/arch/arm64/include/asm/exception.h
@@ -13,6 +13,7 @@
 
 #include <linux/interrupt.h>
 
+#define __exception     __attribute__((section(".exception.text")))
 #ifdef CONFIG_FUNCTION_GRAPH_TRACER
 #define __exception_irq_entry	__irq_entry
 #else

--- a/arch/arm64/include/asm/system_misc.h
+++ b/arch/arm64/include/asm/system_misc.h
@@ -29,6 +29,10 @@ void hook_debug_fault_code(int nr, int (*fn)(unsigned long, unsigned int,
 					     struct pt_regs *),
 			   int sig, int code, const char *name);
 
+void hook_fault_code(int nr, int (*fn)(unsigned long, unsigned int,
+                    struct pt_regs *), int sig, int code, const char *name);
+void *hook_serror_handler(int (*fn)(unsigned long, unsigned int,
+                       struct pt_regs *));
 struct mm_struct;
 extern void __show_regs(struct pt_regs *);
 

--- a/arch/arm64/kernel/entry.S
+++ b/arch/arm64/kernel/entry.S
@@ -33,6 +33,12 @@
  * Context tracking and irqflag tracing need to instrument transitions between
  * user and kernel mode.
  */
+	.macro ct_user_exit
+#ifdef CONFIG_CONTEXT_TRACKING
+	bl      context_tracking_user_exit
+#endif
+	.endm
+
 	.macro user_exit_irqoff
 #if defined(CONFIG_CONTEXT_TRACKING) || defined(CONFIG_TRACE_IRQFLAGS)
 	bl	enter_from_user_mode
@@ -657,7 +663,7 @@ SYM_CODE_START(vectors)
 	kernel_ventry	1, sync_invalid			// Synchronous EL1t
 	kernel_ventry	1, irq_invalid			// IRQ EL1t
 	kernel_ventry	1, fiq_invalid			// FIQ EL1t
-	kernel_ventry	1, error_invalid		// Error EL1t
+	kernel_ventry   1, error                // Error EL1h
 
 	kernel_ventry	1, sync				// Synchronous EL1h
 	kernel_ventry	1, irq				// IRQ EL1h
@@ -748,6 +754,33 @@ SYM_CODE_START_LOCAL(el1_sync_invalid)
 	inv_entry 1, BAD_SYNC
 SYM_CODE_END(el1_sync_invalid)
 
+.align  6
+SYM_CODE_START_LOCAL(el1_error)
+	kernel_entry 1
+	mrs     x1, esr_el1                     // read the syndrome register
+	lsr     x24, x1, #ESR_ELx_EC_SHIFT      // exception class
+	cmp     x24, #ESR_ELx_EC_SERROR         // SError exception in EL1
+	b.ne    el1_error_inv
+el1_serr:
+	mrs     x0, far_el1
+	enable_dbg
+	// re-enable interrupts if they were enabled in the aborted context
+	tbnz    x23, #7, 1f                     // PSR_I_BIT
+	enable_irq
+1:
+	mov     x2, sp                          // struct pt_regs
+	bl      do_serr_abort
+	// disable interrupts before pulling preserved data off the stack
+	disable_irq
+	kernel_exit 1
+	el1_error_inv:
+	enable_dbg
+	mov     x0, sp
+	mov     x2, x1
+	mov     x1, #BAD_ERROR
+	b       bad_mode
+SYM_CODE_END(el1_error)
+
 SYM_CODE_START_LOCAL(el1_irq_invalid)
 	inv_entry 1, BAD_IRQ
 SYM_CODE_END(el1_irq_invalid)
@@ -804,6 +837,7 @@ SYM_CODE_START_LOCAL_NOALIGN(el0_irq_compat)
 	b	el0_irq_naked
 SYM_CODE_END(el0_irq_compat)
 
+       .align  6
 SYM_CODE_START_LOCAL_NOALIGN(el0_error_compat)
 	kernel_entry 0, 32
 	b	el0_error_naked
@@ -817,28 +851,6 @@ el0_irq_naked:
 	el0_interrupt_handler handle_arch_irq
 	b	ret_to_user
 SYM_CODE_END(el0_irq)
-
-SYM_CODE_START_LOCAL(el1_error)
-	kernel_entry 1
-	mrs	x1, esr_el1
-	enable_dbg
-	mov	x0, sp
-	bl	do_serror
-	kernel_exit 1
-SYM_CODE_END(el1_error)
-
-SYM_CODE_START_LOCAL(el0_error)
-	kernel_entry 0
-el0_error_naked:
-	mrs	x25, esr_el1
-	user_exit_irqoff
-	enable_dbg
-	mov	x0, sp
-	mov	x1, x25
-	bl	do_serror
-	enable_da_f
-	b	ret_to_user
-SYM_CODE_END(el0_error)
 
 /*
  * "slow" syscall return path.
@@ -1090,6 +1102,31 @@ SYM_CODE_START(__bp_harden_el1_vectors)
 SYM_CODE_END(__bp_harden_el1_vectors)
 	.popsection
 
+.align  6
+SYM_CODE_START_LOCAL(el0_error)
+	kernel_entry 0
+	el0_error_naked:
+	mrs     x25, esr_el1                    // read the syndrome register
+	lsr     x24, x25, #ESR_ELx_EC_SHIFT     // exception class
+	cmp     x24, #ESR_ELx_EC_SERROR         // SError exception in EL0
+	b.ne    el0_error_inv
+el0_serr:
+	mrs     x26, far_el1
+        // enable interrupts before calling the main handler
+	msr     daifclr, #(8 | 2)
+	ct_user_exit
+	bic     x0, x26, #(0xff << 56)
+	mov     x1, x25
+	mov     x2, sp
+	bl      do_serr_abort
+	b       ret_to_user
+el0_error_inv:
+	enable_dbg
+	mov     x0, sp
+	mov     x1, #BAD_ERROR
+	mov     x2, x25
+	b       bad_mode
+SYM_CODE_END(el0_error)
 
 /*
  * Register switch for AArch64. The callee-saved registers need to be saved

--- a/drivers/pci/controller/pcie-rockchip-host.c
+++ b/drivers/pci/controller/pcie-rockchip-host.c
@@ -366,6 +366,7 @@ static int rockchip_pcie_host_init_port(struct rockchip_pcie *rockchip)
 	rockchip_pcie_write(rockchip, PCIE_CLIENT_LINK_TRAIN_ENABLE,
 			    PCIE_CLIENT_CONFIG);
 
+	msleep(500);
 	gpiod_set_value_cansleep(rockchip->ep_gpio, 1);
 
 	if (rockchip->wait_ep)
@@ -446,6 +447,8 @@ static int rockchip_pcie_host_init_port(struct rockchip_pcie *rockchip)
 	status &= ~PCIE_RC_CONFIG_DCSR_MPS_MASK;
 	status |= PCIE_RC_CONFIG_DCSR_MPS_256;
 	rockchip_pcie_write(rockchip, status, PCIE_RC_CONFIG_DCSR);
+
+	mdelay(500);
 
 	return 0;
 err_power_off_phy:

--- a/drivers/pci/controller/pcie-rockchip-host.c
+++ b/drivers/pci/controller/pcie-rockchip-host.c
@@ -1062,6 +1062,17 @@ err_disable_0v9:
 	return err;
 }
 
+#ifdef CONFIG_ARM64
+static int (*serror_chain)(unsigned long addr, unsigned int esr,
+                               struct pt_regs *regs);
+static int do_rockchip_pcie_serror(unsigned long addr, unsigned int esr,
+                               struct pt_regs *regs)
+{
+	       printk("%s\n", __func__);
+	              return 0;
+}
+#endif
+
 static int rockchip_pcie_really_probe(struct rockchip_pcie *rockchip)
 {
 	int err;
@@ -1079,6 +1090,10 @@ static int rockchip_pcie_really_probe(struct rockchip_pcie *rockchip)
 	err = rockchip_pcie_cfg_atu(rockchip);
 	if (err)
 		return err;
+
+	#ifdef CONFIG_ARM64
+	serror_chain = hook_serror_handler(do_rockchip_pcie_serror);
+	#endif
 
 	rockchip->bridge->sysdata = rockchip;
 	rockchip->bridge->ops = &rockchip_pcie_ops;

--- a/drivers/pci/controller/pcie-rockchip.h
+++ b/drivers/pci/controller/pcie-rockchip.h
@@ -13,6 +13,10 @@
 
 #include <linux/kernel.h>
 #include <linux/pci.h>
+#ifdef CONFIG_ARM64
+#include <asm/signal.h>
+#include <asm/system_misc.h>
+#endif
 
 /*
  * The upper 16 bits of PCIE_CLIENT_CONFIG are a write mask for the lower 16

--- a/drivers/pci/probe.c
+++ b/drivers/pci/probe.c
@@ -2339,7 +2339,7 @@ bool pci_bus_read_dev_vendor_id(struct pci_bus *bus, int devfn, u32 *l,
 	    bridge->device == 0x80b5)
 		return pci_idt_bus_quirk(bus, devfn, l, timeout);
 #endif
-
+	pci_bus_write_config_dword(bus, devfn, PCI_VENDOR_ID, 0x00240000);
 	return pci_bus_generic_read_dev_vendor_id(bus, devfn, l, timeout);
 }
 EXPORT_SYMBOL(pci_bus_read_dev_vendor_id);

--- a/drivers/pci/probe.c
+++ b/drivers/pci/probe.c
@@ -2339,7 +2339,7 @@ bool pci_bus_read_dev_vendor_id(struct pci_bus *bus, int devfn, u32 *l,
 	    bridge->device == 0x80b5)
 		return pci_idt_bus_quirk(bus, devfn, l, timeout);
 #endif
-	pci_bus_write_config_dword(bus, devfn, PCI_VENDOR_ID, 0x00240000);
+
 	return pci_bus_generic_read_dev_vendor_id(bus, devfn, l, timeout);
 }
 EXPORT_SYMBOL(pci_bus_read_dev_vendor_id);


### PR DESCRIPTION
Solved the problem that the pcie driver of rk3399 platform reported an error when connecting to PCIe switch, which caused the system to fail to start normally.