### PR TITLE
net: wireless: rockchip_wlan: modify firmware path to /lib/firmware/brcm

### DIFF
--- a/drivers/net/wireless/rockchip_wlan/rkwifi/Kconfig
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/Kconfig
@@ -39,14 +39,14 @@ config PCIEASPM_ROCKCHIP_WIFI_EXTENSION
 config BCMDHD_FW_PATH
 	depends on BCMDHD
 	string "Firmware path"
-	default "/vendor/etc/firmware/fw_bcmdhd.bin"
+	default "/lib/firmware/brcm/fw_bcmdhd.bin"
 	help
 	  Path to the firmware file.
 
 config BCMDHD_NVRAM_PATH
 	depends on BCMDHD
 	string "NVRAM path"
-	default "/vendor/etc/firmware/nvram.txt"
+	default "/lib/firmware/brcm/nvram.txt"
 	help
 	  Path to the calibration file.a
 

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Kconfig
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Kconfig
@@ -29,14 +29,14 @@ config BCMDHD
 config BCMDHD_FW_PATH
 	depends on BCMDHD
 	string "Firmware path"
-	default "/system/etc/firmware/fw_bcmdhd.bin"
+	default "/lib/firmware/brcm/fw_bcmdhd.bin"
 	help
 	  Path to the firmware file.
 
 config BCMDHD_NVRAM_PATH
 	depends on BCMDHD
 	string "NVRAM path"
-	default "/system/etc/firmware/nvram.txt"
+	default "/lib/firmware/brcm/nvram.txt"
 	help
 	  Path to the calibration file.
 

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Makefile
@@ -41,7 +41,7 @@ CONFIG_BCMDHD_DEBUG := y
 #CONFIG_BCMDHD_TIMESTAMP := y
 #CONFIG_BCMDHD_WAPI := y
 #CONFIG_BCMDHD_RANDOM_MAC := y
-CONFIG_BCMDHD_REQUEST_FW := y
+#CONFIG_BCMDHD_REQUEST_FW := y
 #CONFIG_BCMDHD_FW_SIGNATURE := y
 #CONFIG_BCMDHD_DWDS := y
 CONFIG_BCMDHD_TPUT := y
@@ -429,11 +429,11 @@ ifeq ($(CONFIG_BCMDHD_REQUEST_FW),y)
 else
 	DHDCFLAGS += -DDHD_SUPPORT_VFS_CALL
 ifeq ($(CONFIG_BCMDHD_FW_PATH),)
-	DHDCFLAGS += -DCONFIG_BCMDHD_FW_PATH="\"/vendor/etc/firmware/fw_bcmdhd.bin\""
-	DHDCFLAGS += -DCONFIG_BCMDHD_NVRAM_PATH="\"/vendor/etc/firmware/nvram.txt\""
-	DHDCFLAGS += -DCONFIG_BCMDHD_CLM_PATH="\"/vendor/etc/firmware/clm_bcmdhd.blob\""
+	DHDCFLAGS += -DCONFIG_BCMDHD_FW_PATH="\"/lib/firmware/brcm/fw_bcmdhd.bin\""
+	DHDCFLAGS += -DCONFIG_BCMDHD_NVRAM_PATH="\"/lib/firmware/brcm/nvram.txt\""
+	DHDCFLAGS += -DCONFIG_BCMDHD_CLM_PATH="\"/lib/firmware/brcm/clm_bcmdhd.blob\""
 endif
-	DHDCFLAGS += -DCONFIG_BCMDHD_CONFIG_PATH="\"/vendor/etc/firmware/config.txt\""
+	DHDCFLAGS += -DCONFIG_BCMDHD_CONFIG_PATH="\"/lib/firmware/brcm/config.txt\""
 endif
 
 ifeq ($(CONFIG_BCMDHD_FW_SIGNATURE),y)


### PR DESCRIPTION
If the firmware path is wrong when using the dhd driver, you need to comment out CONFIG_BCMDHD_REQUEST_FW,
and then change the default firmwarm path in Kconfig and Makefile to /lib/firmware/brcm