### PR TITLE
clang-19 fixes for Linux 5.10 gen rkr4.1

### DIFF
--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
@@ -599,7 +599,7 @@ static const struct jadard_panel_desc radxa_display_10hd_ad001_desc = {
 	},
 	.lanes = 4,
 	.format = MIPI_DSI_FMT_RGB888,
-	.init_cmds = cz101b4001_init_cmds,
+	.init_cmds = radxa_display_10hd_ad001_init_cmds,
 	.num_init_cmds = ARRAY_SIZE(radxa_display_10hd_ad001_init_cmds),
 };
 

--- a/drivers/gpu/drm/panel/panel-raspits-tc358762.c
+++ b/drivers/gpu/drm/panel/panel-raspits-tc358762.c
@@ -382,7 +382,7 @@ static int raspits_tc358762_mipi_probe(struct mipi_dsi_device *dsi, const struct
 	struct device_node *backlight, *ddc;
 	struct raspits_tc358762 *panel;
 	struct device *dev = &dsi->dev;
-	int err;
+	int err = 0;
 
 	panel = devm_kzalloc(dev, sizeof(*panel), GFP_KERNEL);
 	if (!panel)

--- a/drivers/gpu/drm/rockchip/cdn-dp-core.c
+++ b/drivers/gpu/drm/rockchip/cdn-dp-core.c
@@ -13,8 +13,6 @@
 #include <linux/regmap.h>
 #include <linux/reset.h>
 
-#include <sound/hdmi-codec.h>
-
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_dp_helper.h>
 #include <drm/drm_edid.h>

--- a/drivers/gpu/drm/rockchip/cdn-dp-core.h
+++ b/drivers/gpu/drm/rockchip/cdn-dp-core.h
@@ -10,6 +10,7 @@
 #include <drm/drm_dp_helper.h>
 #include <drm/drm_panel.h>
 #include <drm/drm_probe_helper.h>
+#include <sound/hdmi-codec.h>
 
 #include "rockchip_drm_drv.h"
 
@@ -60,8 +61,7 @@ struct cdn_dp_port {
 	bool phy_enabled;
 	u8 id;
 };
-typedef void (*hdmi_codec_plugged_cb)(struct device *dev,
-				      bool plugged);
+
 struct cdn_dp_device {
 	struct device *dev;
 	struct drm_device *drm_dev;

--- a/drivers/net/wireless/broadcom/brcm80211/Makefile
+++ b/drivers/net/wireless/broadcom/brcm80211/Makefile
@@ -7,6 +7,7 @@
 
 # common flags
 subdir-ccflags-$(CONFIG_BRCMDBG)	+= -DDEBUG
+subdir-ccflags-y += -I$(srctree)/$(src)/include
 
 obj-$(CONFIG_BRCMUTIL)	+= brcmutil/
 obj-$(CONFIG_BRCMFMAC)	+= brcmfmac/

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/Makefile
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/Makefile
@@ -5,10 +5,6 @@
 # Copyright (c) 2010 Broadcom Corporation
 #
 
-ccflags-y += \
-	-I$(src) \
-	-I$(src)/../include
-
 obj-$(CONFIG_BRCMFMAC) += brcmfmac.o
 brcmfmac-objs += \
 		cfg80211.o \

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/vendor.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/vendor.c
@@ -147,7 +147,7 @@ static int brcmf_cfg80211_vndr_cmds_frameburst(struct wiphy *wiphy,
 					       struct wireless_dev *wdev,
 					       const void *data, int len)
 {
-	int ret;
+	int ret = 0;
 	int val = *(int *)data;
 	struct brcmf_cfg80211_vif *vif;
 	struct brcmf_if *ifp;

--- a/drivers/net/wireless/broadcom/brcm80211/brcmutil/Makefile
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmutil/Makefile
@@ -4,7 +4,6 @@
 #
 # Copyright (c) 2011 Broadcom Corporation
 #
-ccflags-y := -I$(src)/../include
 
 obj-$(CONFIG_BRCMUTIL)	+= brcmutil.o
 brcmutil-objs	= utils.o d11.o

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/dhd_linux_platdev.c
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/dhd_linux_platdev.c
@@ -1067,7 +1067,7 @@ static int dhd_wifi_platform_load_usb(void)
 }
 #endif /* BCMDBUS */
 
-static int dhd_wifi_platform_load()
+static int dhd_wifi_platform_load(void)
 {
 	int err = 0;
 	printf("%s: Enter\n", __FUNCTION__);

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/wl_cfg_btcoex.c
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/wl_cfg_btcoex.c
@@ -406,7 +406,7 @@ void* wl_cfg80211_btcoex_init(struct net_device *ndev)
 	return btco_inf;
 }
 
-void wl_cfg80211_btcoex_deinit()
+void wl_cfg80211_btcoex_deinit(void)
 {
 	if (!btcoex_info_loc)
 		return;

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/Makefile
@@ -20,7 +20,16 @@ ifeq ($(GCC_VER_49),1)
 EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
 endif
 
+ifeq ($(CONFIG_ARCH_ROCKCHIP), y)
+DRV_PATH = $(shell pwd)/$(srctree)/$(src)
+
+EXTRA_CFLAGS += -I$(DRV_PATH)/include
+EXTRA_CFLAGS += -I$(DRV_PATH)/hal/phydm
+EXTRA_CFLAGS += -I$(DRV_PATH)/core/crypto
+EXTRA_CFLAGS += -I$(DRV_PATH)/platform
+else
 EXTRA_CFLAGS += -I$(src)/include
+endif
 
 EXTRA_LDFLAGS += --strip-debug
 
@@ -192,12 +201,14 @@ else
 	HAL = phl
 endif
 
+ifneq ($(CONFIG_ARCH_ROCKCHIP), y)
 ifeq ($(CONFIG_PLATFORM_RTL8198D), y)
 DRV_PATH = $(src)
 else ifeq ($(CONFIG_PLATFORM_ARM_RK3188), y)
 DRV_PATH = $(src)
 else
 DRV_PATH = $(TopDIR)
+endif
 endif
 
 ########### HAL_RTL8852A #################################
@@ -584,7 +595,9 @@ endif
 include $(wildcard $(DRV_PATH)/platform/*.mk)
 
 # Import platform specific compile options
+ifneq ($(CONFIG_ARCH_ROCKCHIP), y)
 EXTRA_CFLAGS += -I$(src)/platform
+endif
 #_PLATFORM_FILES := platform/platform_ops.o
 OBJS += $(_PLATFORM_FILES)
 

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/core/rtw_sta_mgt.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/core/rtw_sta_mgt.c
@@ -386,8 +386,7 @@ void rtw_mfree_stainfo(struct sta_info *psta);
 void rtw_mfree_stainfo(struct sta_info *psta)
 {
 
-	if (&psta->lock != NULL)
-		_rtw_spinlock_free(&psta->lock);
+	_rtw_spinlock_free(&psta->lock);
 
 	_rtw_free_sta_xmit_priv_lock(&psta->sta_xmitpriv);
 	_rtw_free_sta_recv_priv_lock(&psta->sta_recvpriv);

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/core/rtw_vht.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/core/rtw_vht.c
@@ -1416,17 +1416,15 @@ void rtw_reattach_vht_ies(_adapter *padapter, WLAN_BSSID_EX *pnetwork)
 
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
-	if (pnetwork->IEs != NULL) {
-		vht_op_ie = rtw_set_ie(vht_cap_ie, EID_VHTCapability, VHT_CAP_IE_LEN,
-			pvhtpriv->vht_cap_ie_backup, &(pnetwork->IELength));
+	vht_op_ie = rtw_set_ie(vht_cap_ie, EID_VHTCapability, VHT_CAP_IE_LEN,
+		pvhtpriv->vht_cap_ie_backup, &(pnetwork->IELength));
 
-		rtw_set_ie(vht_op_ie, EID_VHTOperation, VHT_OP_IE_LEN,
-			pvhtpriv->vht_op_ie_backup, &(pnetwork->IELength));
+	rtw_set_ie(vht_op_ie, EID_VHTOperation, VHT_OP_IE_LEN,
+		pvhtpriv->vht_op_ie_backup, &(pnetwork->IELength));
 
-		rtw_add_ext_cap_info(pmlmepriv->ext_capab_ie_data, &(pmlmepriv->ext_capab_ie_len), OP_MODE_NOTIFICATION);
-		rtw_update_ext_cap_ie(pmlmepriv->ext_capab_ie_data, pmlmepriv->ext_capab_ie_len, pnetwork->IEs \
-		, &(pnetwork->IELength), _BEACON_IE_OFFSET_);
-	}
+	rtw_add_ext_cap_info(pmlmepriv->ext_capab_ie_data, &(pmlmepriv->ext_capab_ie_len), OP_MODE_NOTIFICATION);
+	rtw_update_ext_cap_ie(pmlmepriv->ext_capab_ie_data, pmlmepriv->ext_capab_ie_len, pnetwork->IEs \
+	, &(pnetwork->IELength), _BEACON_IE_OFFSET_);
 
 	pmlmepriv->vhtpriv.vht_option = _TRUE;
 }

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/os_dep/linux/ioctl_mp.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/os_dep/linux/ioctl_mp.c
@@ -724,7 +724,7 @@ int rtw_mp_txpower(struct net_device *dev,
 {
 	u32 idx_a = 0, idx_b = 0, idx_c = 0, idx_d = 0;
 	int MsetPower = 1;
-	char pout_str_buf[7];
+	char pout_str_buf[8];
 	u8		input[RTW_IWD_MAX_LEN];
 	u8 rfpath_i = 0;
 	u16 agc_cw_val = 0;
@@ -1901,8 +1901,8 @@ int rtw_mp_get_tsside(struct net_device *dev,
 	char input[RTW_IWD_MAX_LEN];
 	u8 rfpath = 0xff;
 	s8 tssi_de = 0;
-	char pout_str_buf[7];
-	char tgr_str_buf[7];
+	char pout_str_buf[8];
+	char tgr_str_buf[8];
 	u8 pout_signed_flag = 0 , tgrpwr_signed_flag = 0;
 	int int_num = 0;
 	u32 dec_num = 0;

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/hal_api_mac.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/hal_api_mac.c
@@ -2640,7 +2640,7 @@ rtw_hal_mac_lv1_rcvy(struct hal_info_t *hal_info, enum rtw_phl_ser_lv1_recv_step
 	u32 mac_err = 0;
 	struct mac_ax_adapter *mac = hal_to_mac(hal_info);
 
-	mac_err = mac->ops->lv1_rcvy(mac, step);
+	mac_err = mac->ops->lv1_rcvy(mac, (enum mac_ax_lv1_rcvy_step)step);
 	if (mac_err != MACSUCCESS) {
 		PHL_ERR("%s : mac status %d.\n", __func__, mac_err);
 		return RTW_HAL_STATUS_FAILURE;
@@ -5837,9 +5837,9 @@ rtw_hal_mac_lps_cfg(struct hal_info_t *hal_info,
 		ax_ps_mode = MAC_AX_PS_MODE_ACTIVE;
 	}
 
-	ax_lps_info.listen_bcn_mode = lps_info->listen_bcn_mode;
+	ax_lps_info.listen_bcn_mode = (enum mac_ax_listern_bcn_mode)lps_info->listen_bcn_mode;
 	ax_lps_info.awake_interval = lps_info->awake_interval;
-	ax_lps_info.smart_ps_mode = lps_info->smart_ps_mode;
+	ax_lps_info.smart_ps_mode = (enum mac_ax_smart_ps_mode)lps_info->smart_ps_mode;
 
 	if (mac->ops->cfg_lps(mac, (u8)lps_info->macid, ax_ps_mode,
 		&ax_lps_info) == MACSUCCESS)

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/rtl8852b/pci/rtl8852be_halinit.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/rtl8852b/pci/rtl8852be_halinit.c
@@ -48,9 +48,9 @@ static enum rtw_hal_status _hal_aspm_disable_8852be(struct hal_info_t *hal_info)
 	/* set ignore to others */
 	pcicfg.wake_ctrl = MAC_AX_PCIE_IGNORE;
 	pcicfg.crq_ctrl = MAC_AX_PCIE_IGNORE;
-	pcicfg.clkdly_ctrl = MAC_AX_PCIE_IGNORE;
-	pcicfg.l0sdly_ctrl = MAC_AX_PCIE_IGNORE;
-	pcicfg.l1dly_ctrl = MAC_AX_PCIE_IGNORE;
+	pcicfg.clkdly_ctrl = (enum mac_ax_pcie_clkdly)MAC_AX_PCIE_IGNORE;
+	pcicfg.l0sdly_ctrl = (enum mac_ax_pcie_l0sdly)MAC_AX_PCIE_IGNORE;
+	pcicfg.l1dly_ctrl = (enum mac_ax_pcie_l1dly)MAC_AX_PCIE_IGNORE;
 
 
 	PHL_TRACE(COMP_PHL_DBG, _PHL_INFO_,

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/test/mp/hal_test_mp_efuse.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/hal_g6/test/mp/hal_test_mp_efuse.c
@@ -192,7 +192,7 @@ enum rtw_hal_status rtw_hal_mp_efuse_shadow2buf(
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
 	PHL_INFO("%s\n", __FUNCTION__);
-	if (arg->poutbuf != NULL && arg->buf_len != 0)
+	if (arg->buf_len != 0)
 		hal_status = rtw_hal_efuse_shadow2buf(mp->hal, arg->poutbuf, arg->buf_len);
 	else
 		PHL_INFO("%s: buf null, buf len = %d\n", __FUNCTION__, arg->buf_len);
@@ -377,7 +377,7 @@ enum rtw_hal_status rtw_hal_mp_efuse_bt_shadow2buf(
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
 	PHL_INFO("%s\n", __FUNCTION__);
-	if (arg->poutbuf != NULL && arg->buf_len != 0)
+	if (arg->buf_len != 0)
 		hal_status = rtw_hal_efuse_bt_shadow2buf(mp->hal, arg->poutbuf, arg->buf_len);
 	else
 		PHL_INFO("%s: buf null, buf len = %d\n", __FUNCTION__, arg->buf_len);

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/phl_ps.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/phl_ps.c
@@ -279,7 +279,7 @@ phl_ps_ips_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, u8 en)
 	ips_info.en = en;
 	ips_info.macid = cfg->macid;
 
-	return rtw_hal_ps_ips_cfg(phl_info->hal, &ips_info);
+	return (enum rtw_phl_status)rtw_hal_ps_ips_cfg(phl_info->hal, &ips_info);
 }
 
 enum rtw_phl_status

--- a/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/phl_sound.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852be/phl/phl_sound.c
@@ -43,10 +43,6 @@ enum rtw_phl_status _phl_snd_init_snd_grp(
 	struct phl_sound_param *param = &snd->snd_param;
 	u8 i = 0;
 	do {
-		if (param->snd_grp == NULL) {
-			status = RTW_PHL_STATUS_FAILURE;
-			break;
-		}
 		for (i = 0; i < MAX_SND_GRP_NUM; i++) {
 			__reset_snd_grp(&param->snd_grp[i]);
 			param->snd_grp[i].gidx = i;

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/Makefile
@@ -20,7 +20,16 @@ ifeq ($(GCC_VER_49),1)
 EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
 endif
 
+ifeq ($(CONFIG_ARCH_ROCKCHIP), y)
+DRV_PATH = $(shell pwd)/$(srctree)/$(src)
+
+EXTRA_CFLAGS += -I$(DRV_PATH)/include
+EXTRA_CFLAGS += -I$(DRV_PATH)/hal/phydm
+EXTRA_CFLAGS += -I$(DRV_PATH)/core/crypto
+EXTRA_CFLAGS += -I$(DRV_PATH)/platform
+else
 EXTRA_CFLAGS += -I$(src)/include
+endif
 
 EXTRA_LDFLAGS += --strip-debug
 
@@ -190,12 +199,14 @@ else
 	HAL = phl
 endif
 
+ifneq ($(CONFIG_ARCH_ROCKCHIP), y)
 ifeq ($(CONFIG_PLATFORM_RTL8198D), y)
 DRV_PATH = $(src)
 else ifeq ($(CONFIG_PLATFORM_ARM_RK3588), y)
 DRV_PATH = $(src)
 else
 DRV_PATH = $(TopDIR)
+endif
 endif
 
 ########### HAL_RTL8852A #################################
@@ -585,7 +596,9 @@ endif
 include $(wildcard $(DRV_PATH)/platform/*.mk)
 
 # Import platform specific compile options
+ifneq ($(CONFIG_ARCH_ROCKCHIP), y)
 EXTRA_CFLAGS += -I$(src)/platform
+endif
 #_PLATFORM_FILES := platform/platform_ops.o
 OBJS += $(_PLATFORM_FILES)
 

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/core/rtw_sta_mgt.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/core/rtw_sta_mgt.c
@@ -386,8 +386,7 @@ void rtw_mfree_stainfo(struct sta_info *psta);
 void rtw_mfree_stainfo(struct sta_info *psta)
 {
 
-	if (&psta->lock != NULL)
-		_rtw_spinlock_free(&psta->lock);
+	_rtw_spinlock_free(&psta->lock);
 
 	_rtw_free_sta_xmit_priv_lock(&psta->sta_xmitpriv);
 	_rtw_free_sta_recv_priv_lock(&psta->sta_recvpriv);

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/core/rtw_vht.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/core/rtw_vht.c
@@ -1420,17 +1420,15 @@ void rtw_reattach_vht_ies(_adapter *padapter, WLAN_BSSID_EX *pnetwork)
 
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
-	if (pnetwork->IEs != NULL) {
-		vht_op_ie = rtw_set_ie(vht_cap_ie, EID_VHTCapability, VHT_CAP_IE_LEN,
-			pvhtpriv->vht_cap_ie_backup, &(pnetwork->IELength));
+	vht_op_ie = rtw_set_ie(vht_cap_ie, EID_VHTCapability, VHT_CAP_IE_LEN,
+		pvhtpriv->vht_cap_ie_backup, &(pnetwork->IELength));
 
-		rtw_set_ie(vht_op_ie, EID_VHTOperation, VHT_OP_IE_LEN,
-			pvhtpriv->vht_op_ie_backup, &(pnetwork->IELength));
+	rtw_set_ie(vht_op_ie, EID_VHTOperation, VHT_OP_IE_LEN,
+		pvhtpriv->vht_op_ie_backup, &(pnetwork->IELength));
 
-		rtw_add_ext_cap_info(pmlmepriv->ext_capab_ie_data, &(pmlmepriv->ext_capab_ie_len), OP_MODE_NOTIFICATION);
-		rtw_update_ext_cap_ie(pmlmepriv->ext_capab_ie_data, pmlmepriv->ext_capab_ie_len, pnetwork->IEs \
-		, &(pnetwork->IELength), _BEACON_IE_OFFSET_);
-	}
+	rtw_add_ext_cap_info(pmlmepriv->ext_capab_ie_data, &(pmlmepriv->ext_capab_ie_len), OP_MODE_NOTIFICATION);
+	rtw_update_ext_cap_ie(pmlmepriv->ext_capab_ie_data, pmlmepriv->ext_capab_ie_len, pnetwork->IEs \
+	, &(pnetwork->IELength), _BEACON_IE_OFFSET_);
 
 	pmlmepriv->vhtpriv.vht_option = _TRUE;
 }

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/os_dep/linux/ioctl_mp.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/os_dep/linux/ioctl_mp.c
@@ -676,7 +676,7 @@ int rtw_mp_txpower(struct net_device *dev,
 {
 	u32 idx_a = 0, idx_b = 0, idx_c = 0, idx_d = 0;
 	int MsetPower = 1;
-	char pout_str_buf[7];
+	char pout_str_buf[8];
 	u8		input[RTW_IWD_MAX_LEN];
 	u8 rfpath_i = 0;
 	u16 agc_cw_val = 0;
@@ -1813,8 +1813,8 @@ int rtw_mp_get_tsside(struct net_device *dev,
 	char input[RTW_IWD_MAX_LEN];
 	u8 rfpath = 0xff;
 	s8 tssi_de = 0;
-	char pout_str_buf[7];
-	char tgr_str_buf[7];
+	char pout_str_buf[8];
+	char tgr_str_buf[8];
 	u8 pout_signed_flag = 0 , tgrpwr_signed_flag = 0;
 	int int_num = 0;
 	u32 dec_num = 0;

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/hal_api_mac.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/hal_api_mac.c
@@ -2660,7 +2660,7 @@ rtw_hal_mac_lv1_rcvy(struct hal_info_t *hal_info, enum rtw_phl_ser_lv1_recv_step
 	u32 mac_err = 0;
 	struct mac_ax_adapter *mac = hal_to_mac(hal_info);
 
-	mac_err = mac->ops->lv1_rcvy(mac, step);
+	mac_err = mac->ops->lv1_rcvy(mac, (enum mac_ax_lv1_rcvy_step)step);
 	if (mac_err != MACSUCCESS) {
 		PHL_ERR("%s : mac status %d.\n", __func__, mac_err);
 		return RTW_HAL_STATUS_FAILURE;
@@ -5679,9 +5679,9 @@ rtw_hal_mac_lps_cfg(struct hal_info_t *hal_info,
 		ax_ps_mode = MAC_AX_PS_MODE_ACTIVE;
 	}
 
-	ax_lps_info.listen_bcn_mode = lps_info->listen_bcn_mode;
+	ax_lps_info.listen_bcn_mode = (enum mac_ax_listern_bcn_mode)lps_info->listen_bcn_mode;
 	ax_lps_info.awake_interval = lps_info->awake_interval;
-	ax_lps_info.smart_ps_mode = lps_info->smart_ps_mode;
+	ax_lps_info.smart_ps_mode = (enum mac_ax_smart_ps_mode)lps_info->smart_ps_mode;
 
 	if (mac->ops->cfg_lps(mac, (u8)lps_info->macid, ax_ps_mode,
 		&ax_lps_info) == MACSUCCESS)

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/phy/bb/halbb_la_mode.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/phy/bb/halbb_la_mode.c
@@ -264,7 +264,7 @@ void halbb_la_mac_cfg_buf_default(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_string_info *buf = &la->la_string_i;
-	enum la_buff_mode_t mode;
+	enum la_buff_mode_t mode = LA_BUF_DISABLE;
 
 	switch (bb->ic_type) {
 	case BB_RTL8852A:

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/test/mp/hal_test_mp_efuse.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/hal_g6/test/mp/hal_test_mp_efuse.c
@@ -192,7 +192,7 @@ enum rtw_hal_status rtw_hal_mp_efuse_shadow2buf(
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
 	PHL_INFO("%s\n", __FUNCTION__);
-	if (arg->poutbuf != NULL && arg->buf_len != 0)
+	if (arg->buf_len != 0)
 		hal_status = rtw_hal_efuse_shadow2buf(mp->hal, arg->poutbuf, arg->buf_len);
 	else
 		PHL_INFO("%s: buf null, buf len = %d\n", __FUNCTION__, arg->buf_len);
@@ -377,7 +377,7 @@ enum rtw_hal_status rtw_hal_mp_efuse_bt_shadow2buf(
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
 	PHL_INFO("%s\n", __FUNCTION__);
-	if (arg->poutbuf != NULL && arg->buf_len != 0)
+	if (arg->buf_len != 0)
 		hal_status = rtw_hal_efuse_bt_shadow2buf(mp->hal, arg->poutbuf, arg->buf_len);
 	else
 		PHL_INFO("%s: buf null, buf len = %d\n", __FUNCTION__, arg->buf_len);

--- a/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/phl_sound.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8852bu/phl/phl_sound.c
@@ -43,10 +43,6 @@ enum rtw_phl_status _phl_snd_init_snd_grp(
 	struct phl_sound_param *param = &snd->snd_param;
 	u8 i = 0;
 	do {
-		if (param->snd_grp == NULL) {
-			status = RTW_PHL_STATUS_FAILURE;
-			break;
-		}
 		for (i = 0; i < MAX_SND_GRP_NUM; i++) {
 			__reset_snd_grp(&param->snd_grp[i]);
 			param->snd_grp[i].gidx = i;


### PR DESCRIPTION
Greetings,

These are all the clang-19 fixes required to build the `rkr4.1` branch. This request includes out-of-srctree build fixes (`O=out`), array and address comparison to NULL pointer, uninitialized variables, potential buffer overflows and implicit enum-conversion errors.
