### PR TITLE
driver: rtc: hym8563: fixed failure to init hym8563 device

### DIFF
--- a/drivers/rtc/rtc-hym8563.c
+++ b/drivers/rtc/rtc-hym8563.c
@@ -556,7 +556,7 @@ static int hym8563_probe(struct i2c_client *client,
 	ret = hym8563_init_device(client);
 	if (ret) {
 		dev_err(&client->dev, "could not init device, %d\n", ret);
-		return ret;
+		return -EPROBE_DEFER;
 	}
 
 	if (client->irq > 0) {


### PR DESCRIPTION
Error Log:
[    1.535354] rtc-hym8563 1-0051: could not init device, -6