### PR TITLE
update rockchip CAN bus driver

### DIFF
--- a/drivers/net/can/rockchip/rockchip_can.c
+++ b/drivers/net/can/rockchip/rockchip_can.c
@@ -501,6 +501,7 @@ static irqreturn_t rockchip_can_interrupt(int irq, void *dev_id)
 	u8 err_int = ERR_WARN_INT | RX_BUF_OV | PASSIVE_ERR |
 		     TX_LOSTARB | BUS_ERR_INT;
 	u8 isr;
+	unsigned int ign;
 
 	isr = readl(rcan->base + CAN_INT);
 	if (isr & TX_FINISH) {
@@ -509,7 +510,7 @@ static irqreturn_t rockchip_can_interrupt(int irq, void *dev_id)
 				   CAN_DLC_MASK;
 		stats->tx_packets++;
 		rockchip_can_write_cmdreg(rcan, 0);
-		can_get_echo_skb(ndev, 0);
+		ign = can_get_echo_skb(ndev, 0, NULL);
 		netif_wake_queue(ndev);
 	}
 

--- a/drivers/net/can/rockchip/rockchip_can.c
+++ b/drivers/net/can/rockchip/rockchip_can.c
@@ -334,7 +334,7 @@ static void rockchip_can_rx(struct net_device *ndev)
 		return;
 
 	fi = readl(rcan->base + CAN_RX_FRM_INFO);
-	cf->can_dlc = get_can_dlc(fi & CAN_DLC_MASK);
+	cf->can_dlc = can_cc_dlc2len(fi & CAN_DLC_MASK);
 	id = readl(rcan->base + CAN_RX_ID);
 	if (fi & CAN_EFF)
 		id |= CAN_EFF_FLAG;

--- a/drivers/net/can/rockchip/rockchip_can.c
+++ b/drivers/net/can/rockchip/rockchip_can.c
@@ -308,7 +308,7 @@ static int rockchip_can_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 	}
 
 	writel(fi, rcan->base + CAN_TX_FRM_INFO);
-	can_put_echo_skb(skb, ndev, 0);
+	can_put_echo_skb(skb, ndev, 0, 0);
 
 	rockchip_can_write_cmdreg(rcan, TX_REQ);
 	netdev_dbg(ndev, "TX: can_id:0x%08x dlc: %d mode: 0x%08x data: 0x%08x 0x%08x\n",

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -794,7 +794,7 @@ static int rockchip_canfd_err(struct net_device *ndev, u32 isr)
 		cancel_delayed_work(&rcan->tx_err_work);
 		netif_stop_queue(ndev);
 		rockchip_canfd_stop(ndev);
-		can_free_echo_skb(ndev, 0);
+		can_free_echo_skb(ndev, 0, NULL);
 		rockchip_canfd_start(ndev);
 		netif_start_queue(ndev);
 	}

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -1146,7 +1146,7 @@ static int rockchip_canfd_probe(struct platform_device *pdev)
 
 	if (rcan->mode == ROCKCHIP_RK3568_CAN_MODE_V2) {
 		rcan->txtorx = 0;
-		netif_napi_add(ndev, &rcan->napi, rockchip_canfd_rx_poll, 6);
+		netif_napi_add_weight(ndev, &rcan->napi, rockchip_canfd_rx_poll, 6);
 	}
 
 	ndev->netdev_ops = &rockchip_canfd_netdev_ops;

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -550,7 +550,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 	if (cf->can_id & CAN_EFF_FLAG) {
 		/* Extended CAN ID format */
 		id = cf->can_id & CAN_EFF_MASK;
-		dlc = can_len2dlc(cf->len) & DLC_MASK;
+		dlc = can_fd_len2dlc(cf->len) & DLC_MASK;
 		dlc |= FORMAT_MASK;
 
 		/* Extended frames remote TX request */
@@ -559,7 +559,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 	} else {
 		/* Standard CAN ID format */
 		id = cf->can_id & CAN_SFF_MASK;
-		dlc = can_len2dlc(cf->len) & DLC_MASK;
+		dlc = can_fd_len2dlc(cf->len) & DLC_MASK;
 
 		/* Standard frames remote TX request */
 		if (cf->can_id & CAN_RTR_FLAG)
@@ -664,7 +664,7 @@ static int rockchip_canfd_rx(struct net_device *ndev)
 
 	/* Change CAN data length format to socketCAN data format */
 	if (dlc & FDF_MASK)
-		cf->len = can_dlc2len(dlc & DLC_MASK);
+		cf->len = can_fd_dlc2len(dlc & DLC_MASK);
 	else
 		cf->len = can_cc_dlc2len(dlc & DLC_MASK);
 
@@ -829,7 +829,7 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 		dlc = rockchip_canfd_read(rcan, CAN_TXFIC);
 		/* transmission complete interrupt */
 		if (dlc & FDF_MASK)
-			stats->tx_bytes += can_dlc2len(dlc & DLC_MASK);
+			stats->tx_bytes += can_fd_dlc2len(dlc & DLC_MASK);
 		else
 			stats->tx_bytes += (dlc & DLC_MASK);
 		stats->tx_packets++;

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -595,7 +595,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 		for (i = 0; i < cf->len; i += 4)
 			rockchip_canfd_write(rcan, CAN_TXDAT0 + i,
 					     *(u32 *)(cf->data + i));
-		can_put_echo_skb(skb, ndev, 0);
+		can_put_echo_skb(skb, ndev, 0, 0);
 		rockchip_canfd_write(rcan, CAN_CMD, CAN_TX1_REQ);
 		local_irq_restore(flags);
 		return NETDEV_TX_OK;
@@ -608,7 +608,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 		rockchip_canfd_write(rcan, CAN_TXDAT0 + i,
 				     *(u32 *)(cf->data + i));
 
-	can_put_echo_skb(skb, ndev, 0);
+	can_put_echo_skb(skb, ndev, 0, 0);
 	rockchip_canfd_write(rcan, CAN_MODE,
 			     rockchip_canfd_read(rcan, CAN_MODE) | MODE_SPACE_RX);
 	rockchip_canfd_write(rcan, CAN_CMD, cmd);

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -666,7 +666,7 @@ static int rockchip_canfd_rx(struct net_device *ndev)
 	if (dlc & FDF_MASK)
 		cf->len = can_dlc2len(dlc & DLC_MASK);
 	else
-		cf->len = get_can_dlc(dlc & DLC_MASK);
+		cf->len = can_cc_dlc2len(dlc & DLC_MASK);
 
 	/* Change CAN ID format to socketCAN ID format */
 	if (dlc & FORMAT_MASK) {

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -817,6 +817,8 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 	u32 dlc = 0;
 	u32 quota, work_done = 0;
 
+	unsigned int ign;
+
 	isr = rockchip_canfd_read(rcan, CAN_INT);
 	if (isr & TX_FINISH_INT) {
 		cancel_delayed_work(&rcan->tx_err_work);
@@ -843,7 +845,7 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 					     0, 5000000, false, rcan, CAN_CMD))
 			netdev_err(ndev, "Warning: wait tx req timeout!\n");
 		rockchip_canfd_write(rcan, CAN_CMD, 0);
-		can_get_echo_skb(ndev, 0);
+		ign = can_get_echo_skb(ndev, 0, NULL);
 		netif_wake_queue(ndev);
 	}
 


### PR DESCRIPTION
The kernel interfaces have changed since the last time the rockchip can driver was touched.

As I need this to work i dug through the kernel history to find the changes that happened and get the driver to compile again.

This has been tested to work on the Rock 5B