### PR TITLE
arm64: dts: rockchip: update cm3j dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
@@ -242,9 +242,9 @@
 &gpio3 {
 	gpio-line-names =
 		/* GPIO3_A0-A3 */
-		"PIN_29", "PIN_18", "PIN_22", "",
+		"PIN_29", "PIN_18", "PIN_22", "PIN_12",
 		/* GPIO3_A4-A7 */
-		"PIN_36", "PIN_40", "PIN_38", "",
+		"PIN_35", "PIN_40", "PIN_38", "",
 
 		/* GPIO3_B0-B3 */
 		"", "PIN_13", "PIN_11", "PIN_28",
@@ -252,7 +252,7 @@
 		"PIN_27", "PIN_5", "PIN_3", "PIN_32",
 
 		/* GPIO3_C0-C3 */
-		"PIN_15", "PIN_16", "PIN_12", "PIN_35",
+		"PIN_15", "PIN_16", "PIN_26", "PIN_36",
 		/* GPIO3_C4-C7 */
 		"", "PIN_37", "", "",
 

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
@@ -21,6 +21,19 @@
 		regulator-max-microvolt = <12000000>;
 	};
 
+	usb20_reset: usb20-reset-regulator {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio0 RK_PC0 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb20_reset_pin>;
+		regulator-name = "usb20_reset";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
 	hdmi_sound: hdmi-sound {
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
@@ -146,6 +159,14 @@
 		status = "okay";
 		reg = <0x51>;
 		quartz-load-femtofarads = <12500>;
+	};
+};
+
+&pinctrl {
+	usb {
+		usb20_reset_pin: usb20-reset {
+			rockchip,pins = <0 RK_PC0 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
 	};
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j.dtsi
@@ -422,7 +422,20 @@
 			status = "disabled";
 		};
 	};
-}; 
+};
+
+&i2c2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2m0_xfer>;
+
+	eeprom:	bl24c16@50 {
+		status = "okay";
+		compatible = "atmel,24c16";
+		reg = <0x50>;
+		pagesize = <16>;
+	};
+};
 
 &i2s1_8ch {
 	status = "disabled";


### PR DESCRIPTION
1. added eeprom support in rk3568-radxa-cm3j.dtsi
2. added support for the reset pin of the usb2.0 hub on the rpi-cm4-io board in rk3568-radxa-cm3j-rpi-cm4-io.dts (low to high enable)
3. updated some PIN pins in gpiod in rk3568-radxa-cm3j-rpi-cm4-io.dts