### PR TITLE
cpufreq: rockchip: fix incorrect config flag

### DIFF
--- a/drivers/cpufreq/cpufreq-dt.c
+++ b/drivers/cpufreq/cpufreq-dt.c
@@ -160,7 +160,7 @@ out_clk_put:
 
 static int cpufreq_online(struct cpufreq_policy *policy)
 {
-#ifdef CONFIG_ARCH_ROCKCHIP
+#ifdef CONFIG_ARM_ROCKCHIP_CPUFREQ
 	return rockchip_cpufreq_online(policy->cpu);
 #endif
 	/* We did light-weight tear down earlier, nothing to do here */
@@ -169,7 +169,7 @@ static int cpufreq_online(struct cpufreq_policy *policy)
 
 static int cpufreq_offline(struct cpufreq_policy *policy)
 {
-#ifdef CONFIG_ARCH_ROCKCHIP
+#ifdef CONFIG_ARM_ROCKCHIP_CPUFREQ
 	return rockchip_cpufreq_offline(policy->cpu);
 #endif
 	/*


### PR DESCRIPTION
Using the `CONFIG_ARCH_ROCKCHIP` flag for function calls to `rockchip_cpufreq_online` and `rockchip_cpufreq_offline` is incorrect. These functions are declared under the `CONFIG_ARM_ROCKCHIP_CPUFREQ` flag [1](https://github.com/radxa/kernel/blob/697921484a2de2e674b51695edf729e5936a4bf2/drivers/cpufreq/rockchip-cpufreq.h#L8). As a result, using `CONFIG_ARCH_ROCKCHIP` can lead to implicit declaration errors if the correct config flag (`CONFIG_ARM_ROCKCHIP_CPUFREQ`) is not enabled.

This patch updates the conditional preprocessor directive to use `CONFIG_ARM_ROCKCHIP_CPUFREQ`, ensuring consistency with the function declarations and preventing potential compilation issues.