### PR TITLE
media: rockchip: hdmirx: hdmirx_audio_startup always return 0 PulseAu…

### DIFF
--- a/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
+++ b/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
@@ -3518,8 +3518,8 @@ static int hdmirx_audio_startup(struct device *dev, void *data)
 
 	if (tx_5v_power_present(hdmirx_dev) && hdmirx_dev->audio_present)
 		return 0;
-	dev_err(dev, "%s: device is no connected or audio is off\n", __func__);
-	return -ENODEV;
+	dev_dbg(dev, "%s: device is no connected or audio is off\n", __func__);
+	return 0;
 }
 
 static void hdmirx_audio_shutdown(struct device *dev, void *data)


### PR DESCRIPTION
…dio would fail to load alsa card if hdmirx_audio_startup return error