### PR TITLE
Revert "arm64: dts: rockchip: fix audio-supply for Rock Pi 4"

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -541,7 +541,7 @@
 	status = "okay";
 
 	bt656-supply = <&vcc_3v0>;
-	audio-supply = <&vcc1v8_codec>;
+	audio-supply = <&vcc_3v0>;
 	sdmmc-supply = <&vcc_sdio>;
 	gpio1830-supply = <&vcc_3v0>;
 };


### PR DESCRIPTION
This reverts commit 24983f750881b57f7476c51a3d07b08e017f425c.

APIO5_VDD is connected to VCC_3V0 [1], this commit causes a spi1 bus driver strength exception [2].

[1] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/4bp/radxa_rock_4bp_v1600_schematic.pdf
[2] https://forum.radxa.com/t/problem-using-i2s-and-spi-on-the-gpio-header-of-the-rock-pi-4b/25390/5