### PR TITLE
arm64: dts: cm3 io: Set i2c2_m1 as default I2C channel for RTC

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
@@ -220,6 +220,8 @@
 
 &i2c2 {
 	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2m1_xfer>;
 	hym8563: hym8563@51 {
 		compatible = "haoyu,hym8563";
 		status = "okay";


### PR DESCRIPTION
This change adapts to hardware version v1.36 requirements.