### PR TITLE
leds: Add driver for the YONGFUKANG HTR32XX family of LED controllers

### DIFF
--- a/Documentation/devicetree/bindings/serial/rs485.yaml
+++ b/Documentation/devicetree/bindings/serial/rs485.yaml
@@ -51,6 +51,9 @@ properties:
     description: GPIO pin to enable RS485 bus termination.
     maxItems: 1
 
+  rs485-de-gpios:
+    description: if using other gpio instead of rts, set this gpio.
+
 additionalProperties: true
 
 ...

--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
@@ -13,6 +13,7 @@
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/input/rk-input.h>
 #include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/display/rockchip_vop.h>
 #include <dt-bindings/sensor-dev.h>
 #include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
@@ -578,6 +579,13 @@
 
 &vop_mmu {
 	status = "okay";
+};
+
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
+				1 << ROCKCHIP_VOP2_SMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
+	cursor-win-id = <ROCKCHIP_VOP2_ESMART0>;
 };
 
 &i2c3 {

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dtsi
@@ -12,6 +12,7 @@
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/input/rk-input.h>
 #include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/display/rockchip_vop.h>
 #include <dt-bindings/sensor-dev.h>
 #include "rk3566.dtsi"
 #include "rk3568-linux.dtsi"
@@ -786,6 +787,13 @@
 
 &vop_mmu {
 	status = "okay";
+};
+
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
+				1 << ROCKCHIP_VOP2_SMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
+	cursor-win-id = <ROCKCHIP_VOP2_ESMART0>;
 };
 
 &rockchip_suspend {

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 
+#include <dt-bindings/display/rockchip_vop.h>
 #include "rk3568-radxa-cm3i.dtsi"
 
 / {
@@ -307,6 +308,13 @@
 	assigned-clock-rates = <200000000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&can1m0_pins>;
+};
+
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
+				1 << ROCKCHIP_VOP2_SMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
+	cursor-win-id = <ROCKCHIP_VOP2_ESMART0>;
 };
 
 &pinctrl {

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/display/rockchip_vop.h>
 #include "rk3568.dtsi"
 
 / {
@@ -728,4 +729,8 @@
 		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
 		remote-endpoint = <&hdmi_in_vp0>;
 	};
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
+				1 << ROCKCHIP_VOP2_SMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
+	cursor-win-id = <ROCKCHIP_VOP2_ESMART0>;
 };

--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -307,6 +307,14 @@ config LEDS_HP6XX
 	  This option enables LED support for the handheld
 	  HP Jornada 620/660/680/690.
 
+config LEDS_HTR32XX
+	tristate "LED support for YONGFUKANG HTR32XX I2C LED controller family"
+	depends on LEDS_CLASS && I2C && OF
+	help
+	  Say Y here to include support for YONGFUKANG HTR32XX LED controllers.
+	  They are I2C devices with multiple constant-current channels, each
+	  with independent 256-level PWM control.
+
 config LEDS_PCA9532
 	tristate "LED driver for PCA9532 dimmer"
 	depends on LEDS_CLASS

--- a/drivers/leds/Makefile
+++ b/drivers/leds/Makefile
@@ -29,6 +29,7 @@ obj-$(CONFIG_LEDS_DA9052)		+= leds-da9052.o
 obj-$(CONFIG_LEDS_GPIO)			+= leds-gpio.o
 obj-$(CONFIG_LEDS_GPIO_REGISTER)	+= leds-gpio-register.o
 obj-$(CONFIG_LEDS_HP6XX)		+= leds-hp6xx.o
+obj-$(CONFIG_LEDS_HTR32XX)		+= leds-htr32xx.o
 obj-$(CONFIG_LEDS_INTEL_SS4200)		+= leds-ss4200.o
 obj-$(CONFIG_LEDS_IP30)			+= leds-ip30.o
 obj-$(CONFIG_LEDS_IPAQ_MICRO)		+= leds-ipaq-micro.o

--- a/drivers/leds/leds-htr32xx.c
+++ b/drivers/leds/leds-htr32xx.c
@@ -1,0 +1,275 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Driver for HTR32xx family of I2C LED controllers
+ *
+ * Copyright (c) 2025 Radxa Computer (Shenzhen) Co., Ltd.
+ *
+ * Based on drivers/leds/leds-is31fl32xx.c:
+ * Copyright (c) 2015 Allworx Corp.
+ * David Rivshin <drivshin@allworx.com>
+ *
+ * Steps:
+ *  1. Software enable: write 0x00 = 0x01
+ *  2. Select 22kHz PWM (opt): write 0x4B = 0x01
+ *  3. Enable channels: set each enable register = 0x01
+ *  4. Set PWM values: write each PWM reg
+ *  5. Update: write 0x25 = 0x00
+ *  6. Shutdown: write 0x00 = 0x00 (and 0x4F=0x00 to reset)
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/i2c.h>
+#include <linux/leds.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/delay.h>
+
+#define HTR32XX_REG_NONE 0xFF
+
+struct htr32xx_priv;
+struct htr32xx_led {
+	u8 channel;      /* 1-based channel number */
+	struct led_classdev cdev;
+	struct htr32xx_priv *priv;
+	struct work_struct work; /* For asynchronous execution of I²C writes */
+};
+
+struct htr32xx_chipdef {
+	u8 channels;
+	u8 shutdown_reg;
+	u8 pwm_update_reg;
+	u8 global_ctrl_reg;
+	u8 reset_reg;
+	u8 pwm_base;
+	bool pwm_reversed;
+	u8 en_base;
+	u8 en_regs;
+	u8 en_per_reg;
+};
+
+struct htr32xx_priv {
+	struct i2c_client *client;
+	const struct htr32xx_chipdef *cdef;
+	u8 num_leds;
+	struct htr32xx_led leds[];
+};
+
+static int htr32xx_write(struct htr32xx_priv *priv, u8 reg, u8 val)
+{
+	int ret;
+	ret = i2c_smbus_write_byte_data(priv->client, reg, val);
+	if (ret < 0)
+		dev_err(&priv->client->dev,
+			"write reg 0x%02x failed: %d\n", reg, ret);
+	return ret;
+}
+
+static int htr32xx_reset_regs(struct htr32xx_priv *priv)
+{
+	const struct htr32xx_chipdef *c = priv->cdef;
+	int ret, i;
+
+	/* reset-specific reg */
+	if (c->reset_reg != HTR32XX_REG_NONE) {
+		ret = htr32xx_write(priv, c->reset_reg, 0x00);
+		if (ret)
+			return ret;
+		msleep(10);
+	}
+
+	/* software enable */
+	ret = htr32xx_write(priv, c->shutdown_reg, 0x01);
+	if (ret)
+		return ret;
+	msleep(10);
+
+	/* optional PWM freq sel */
+	if (c->global_ctrl_reg != HTR32XX_REG_NONE) {
+		ret = htr32xx_write(priv, c->global_ctrl_reg, 0x01);
+		if (ret)
+			return ret;
+		msleep(10);
+	}
+
+	/* enable all channels */
+	for (i = 0; i < c->en_regs; i++) {
+		ret = htr32xx_write(priv, c->en_base + i, GENMASK(c->en_per_reg - 1, 0));
+		if (ret)
+			return ret;
+	}
+
+	return htr32xx_write(priv, c->pwm_update_reg, 0x00);
+}
+
+static int htr32xx_set_brightness(struct led_classdev *cdev,
+		   enum led_brightness brightness)
+{
+	struct htr32xx_led *led = container_of(cdev, struct htr32xx_led, cdev);
+	cdev->brightness = brightness;
+	schedule_work(&led->work);
+	return 0;
+}
+
+/**
+ * work handler: Execute the actual I2C write in a non-atomic context
+ */
+static void htr32xx_brightness_work(struct work_struct *w)
+{
+	struct htr32xx_led *led = container_of(w, struct htr32xx_led, work);
+	struct htr32xx_priv *priv = led->priv;
+	const struct htr32xx_chipdef *c = priv->cdef;
+	u8 idx = led->channel - 1;
+	htr32xx_write(priv, c->pwm_base + idx, led->cdev.brightness);
+	htr32xx_write(priv, c->pwm_update_reg, 0x00);
+}
+
+static int htr32xx_probe(struct i2c_client *client,
+			const struct i2c_device_id *id)
+{
+	struct device_node *child;
+	struct device_node *np = client->dev.of_node;
+	struct htr32xx_priv *priv;
+	const struct htr32xx_chipdef *cdef;
+	int count, i, ret;
+
+	cdef = of_device_get_match_data(&client->dev);
+	if (!cdef)
+		return -EINVAL;
+
+	count = of_get_available_child_count(np);
+	if (!count)
+		return -EINVAL;
+
+	priv = devm_kzalloc(&client->dev,
+			sizeof(*priv) + count * sizeof(struct htr32xx_led),
+			GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->client = client;
+	priv->cdef = cdef;
+
+	/* init regs */
+	ret = htr32xx_reset_regs(priv);
+	if (ret)
+		return ret;
+
+	/* register leds */
+	i = 0;
+	for_each_available_child_of_node(np, child) {
+		struct led_init_data init_data = {};
+		struct htr32xx_led *led = &priv->leds[i];
+		struct led_classdev *cdev = &led->cdev;
+		u32 channel;
+		const char *label;
+
+		of_property_read_u32(child, "reg", &channel);
+		led->channel = channel;
+		led->priv = priv;
+
+		of_property_read_string(child, "label", &label);
+		cdev->name = devm_kasprintf(&client->dev, GFP_KERNEL,
+			"%s:%s", dev_name(&client->dev), label ?: "led");
+		cdev->brightness_set = htr32xx_set_brightness;
+		INIT_WORK(&led->work, htr32xx_brightness_work);
+		cdev->max_brightness = 0xFF;
+
+		init_data.fwnode = of_fwnode_handle(child);
+		ret = devm_led_classdev_register_ext(&client->dev,
+			cdev, &init_data);
+		if (ret)
+			return ret;
+		i++;
+	}
+
+	priv->num_leds = i;
+	i2c_set_clientdata(client, priv);
+
+	return 0;
+}
+
+static int htr32xx_remove(struct i2c_client *client)
+{
+	struct htr32xx_priv *priv = i2c_get_clientdata(client);
+	struct htr32xx_chipdef const *c = priv->cdef;
+
+	/* shutdown */
+	htr32xx_write(priv, c->shutdown_reg, 0x00);
+	msleep(10);
+	/* reset regs if needed */
+	if (c->reset_reg != HTR32XX_REG_NONE)
+		htr32xx_write(priv, c->reset_reg, 0x00);
+
+	return 0;
+}
+
+static const struct htr32xx_chipdef htr3236_def = {
+	.channels = 36,
+	.shutdown_reg = 0x00,
+	.pwm_update_reg = 0x25,
+	.global_ctrl_reg = 0x4B,
+	.reset_reg = 0x4F,
+	.pwm_base = 0x01,
+	.pwm_reversed = false,
+	.en_base = 0x26,
+	.en_regs = 36,
+	.en_per_reg = 1,
+};
+
+static const struct htr32xx_chipdef htr3218_def = {
+	.channels = 18,
+	.shutdown_reg = 0x00,
+	.pwm_update_reg = 0x25,
+	.global_ctrl_reg = 0x4B,
+	.reset_reg = 0x4F,
+	.pwm_base = 0x0A,
+	.pwm_reversed = false,
+	.en_base = 0x2F,
+	.en_regs = 18,
+	.en_per_reg = 1,
+};
+
+static const struct htr32xx_chipdef htr3212_def = {
+	.channels = 12,
+	.shutdown_reg = 0x00,
+	.pwm_update_reg = 0x25,
+	.global_ctrl_reg = 0x4B,
+	.reset_reg = 0x4F,
+	.pwm_base = 0x0D,
+	.pwm_reversed = false,
+	.en_base = 0x32,
+	.en_regs = 12,
+	.en_per_reg = 1,
+};
+
+static const struct of_device_id htr32xx_of_match[] = {
+	{ .compatible = "htr,htr3236", .data = &htr3236_def },
+	{ .compatible = "htr,htr3218", .data = &htr3218_def },
+	{ .compatible = "htr,htr3212", .data = &htr3212_def },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, htr32xx_of_match);
+
+static const struct i2c_device_id htr32xx_id[] = {
+	{ "htr3236", 0 },
+	{ "htr3218", 0 },
+	{ "htr3212", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, htr32xx_id);
+
+static struct i2c_driver htr32xx_driver = {
+	.driver = {
+		.name = "htr32xx",
+		.of_match_table = htr32xx_of_match,
+	},
+	.probe = htr32xx_probe,
+	.remove = htr32xx_remove,
+	.id_table = htr32xx_id,
+};
+module_i2c_driver(htr32xx_driver);
+
+MODULE_AUTHOR("Jiali Chen <chenjiali@radxa.com>");
+MODULE_DESCRIPTION("HTR32xx LED driver");
+MODULE_LICENSE("GPL v2");

--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -185,7 +185,9 @@ static inline bool serial8250_set_THRI(struct uart_8250_port *up)
 		return false;
 	up->ier |= UART_IER_THRI;
 #if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
-	up->ier |= UART_IER_PTIME;
+	/* Disable PTIME when it is rs485 mode*/
+	if (!up->em485)
+		up->ier |= UART_IER_PTIME;
 #endif
 	serial_out(up, UART_IER, up->ier);
 	return true;
@@ -197,7 +199,8 @@ static inline bool serial8250_clear_THRI(struct uart_8250_port *up)
 		return false;
 	up->ier &= ~UART_IER_THRI;
 #if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
-	up->ier &= ~UART_IER_PTIME;
+	if (!up->em485)
+		up->ier &= ~UART_IER_PTIME;
 #endif
 	serial_out(up, UART_IER, up->ier);
 	return true;

--- a/drivers/tty/serial/8250/8250_dw.c
+++ b/drivers/tty/serial/8250/8250_dw.c
@@ -595,7 +595,11 @@ static int dw8250_probe(struct platform_device *pdev)
 	p->serial_out	= dw8250_serial_out;
 	p->set_ldisc	= dw8250_set_ldisc;
 	p->set_termios	= dw8250_set_termios;
-
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	p->rs485_config = serial8250_em485_config;
+	uart.rs485_start_tx = serial8250_em485_start_tx;
+	uart.rs485_stop_tx = serial8250_em485_stop_tx;
+#endif
 	p->membase = devm_ioremap(dev, regs->start, resource_size(regs));
 	if (!p->membase)
 		return -ENOMEM;

--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -55,6 +55,14 @@
 #define DEBUG_AUTOCONF(fmt...)	do { } while (0)
 #endif
 
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+#if 0
+#define DEBUG_EM485(fmt...)	printk(fmt)
+#else
+#define DEBUG_EM485(fmt...)	do { } while (0)
+#endif
+#endif
+
 /*
  * Here we define the default xmit fifo size used for each type of UART.
  */
@@ -612,6 +620,10 @@ EXPORT_SYMBOL_GPL(serial8250_rpm_put);
  */
 static int serial8250_em485_init(struct uart_8250_port *p)
 {
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	DEBUG_EM485("%s ttyS%d\n", __func__, p->port.line);
+#endif
+
 	if (p->em485)
 		goto deassert_rts;
 
@@ -1445,12 +1457,32 @@ void serial8250_em485_stop_tx(struct uart_8250_port *p)
 {
 	unsigned char mcr = serial8250_in_MCR(p);
 
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	int value = 0;
+
+	if (p->port.rs485_de_gpio) {
+		if (p->port.rs485.flags & SER_RS485_RTS_AFTER_SEND)
+			value = 0;
+		else
+			value = 1;
+
+		gpiod_set_value(p->port.rs485_de_gpio, value);
+		DEBUG_EM485("%s ttyS%d gpio:%d\n", __func__, p->port.line, value);
+	} else {
+		if (p->port.rs485.flags & SER_RS485_RTS_AFTER_SEND)
+			mcr |= UART_MCR_RTS;
+		else
+			mcr &= ~UART_MCR_RTS;
+		serial8250_out_MCR(p, mcr);
+		DEBUG_EM485("%s ttyS%d mcr:%02x\n", __func__, p->port.line, mcr);
+	}
+#else
 	if (p->port.rs485.flags & SER_RS485_RTS_AFTER_SEND)
 		mcr |= UART_MCR_RTS;
 	else
 		mcr &= ~UART_MCR_RTS;
 	serial8250_out_MCR(p, mcr);
-
+#endif
 	/*
 	 * Empty the RX FIFO, we are not interested in anything
 	 * received during the half-duplex transmission.
@@ -1494,6 +1526,10 @@ static void __stop_tx_rs485(struct uart_8250_port *p, u64 stop_delay)
 {
 	struct uart_8250_em485 *em485 = p->em485;
 
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	DEBUG_EM485("%s ttyS%d\n", __func__, p->port.line);
+#endif
+
 	stop_delay += (u64)p->port.rs485.delay_rts_after_send * NSEC_PER_MSEC;
 
 	/*
@@ -1531,6 +1567,9 @@ static inline void __stop_tx(struct uart_8250_port *p)
 		 * for emptying of the shift register.
 		 */
 		if (!(lsr & UART_LSR_TEMT)) {
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+			stop_delay = p->port.frame_time + 10000;
+#else
 			if (!(p->capabilities & UART_CAP_NOTEMT))
 				return;
 			/*
@@ -1541,6 +1580,7 @@ static inline void __stop_tx(struct uart_8250_port *p)
 			 * Roughly estimate 1 extra bit here with / 7.
 			 */
 			stop_delay = p->port.frame_time + DIV_ROUND_UP(p->port.frame_time, 7);
+#endif
 		}
 
 		__stop_tx_rs485(p, stop_delay);
@@ -1610,15 +1650,30 @@ static inline void __start_tx(struct uart_port *port)
 void serial8250_em485_start_tx(struct uart_8250_port *up)
 {
 	unsigned char mcr = serial8250_in_MCR(up);
-
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	int value = 0;
+#endif
 	if (!(up->port.rs485.flags & SER_RS485_RX_DURING_TX))
 		serial8250_stop_rx(&up->port);
-
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	if (up->port.rs485_de_gpio) {
+		if (up->port.rs485.flags & SER_RS485_RTS_ON_SEND)
+			value = 0;
+		else
+			value = 1;
+		gpiod_set_value(up->port.rs485_de_gpio, value);
+		DEBUG_EM485("%s ttyS%d gpio:%d\n", __func__, up->port.line, value);
+		return;
+	}
+#endif
 	if (up->port.rs485.flags & SER_RS485_RTS_ON_SEND)
 		mcr |= UART_MCR_RTS;
 	else
 		mcr &= ~UART_MCR_RTS;
 	serial8250_out_MCR(up, mcr);
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	DEBUG_EM485("%s ttyS%d mcr:%02x\n", __func__, up->port.line, mcr);
+#endif
 }
 EXPORT_SYMBOL_GPL(serial8250_em485_start_tx);
 

--- a/drivers/tty/serial/serial_core.c
+++ b/drivers/tty/serial/serial_core.c
@@ -3490,6 +3490,12 @@ int uart_get_rs485_mode(struct uart_port *port)
 	if (port->rs485_term_gpio)
 		port->rs485_supported.flags |= SER_RS485_TERMINATE_BUS;
 
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	port->rs485_de_gpio = devm_gpiod_get_optional(dev, "rs485-de",
+							GPIOD_OUT_LOW);
+	if (IS_ERR(port->rs485_de_gpio))
+		port->rs485_de_gpio = NULL;
+#endif
 	return 0;
 }
 EXPORT_SYMBOL_GPL(uart_get_rs485_mode);

--- a/include/linux/serial_core.h
+++ b/include/linux/serial_core.h
@@ -579,6 +579,9 @@ struct uart_port {
 	struct serial_rs485     rs485;
 	struct serial_rs485	rs485_supported;	/* Supported mask for serial_rs485 */
 	struct gpio_desc	*rs485_term_gpio;	/* enable RS485 bus termination */
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	struct gpio_desc	*rs485_de_gpio;		/* enable RS485 de */
+#endif
 	struct serial_iso7816   iso7816;
 	void			*private_data;		/* generic platform data pointer */
 };


### PR DESCRIPTION
The YONGFUKANG HTR32XX of LED controllers are I2C devices with multiple constant-current channels, each with independent 256-level PWM control.

This has been tested on the HTR3212, on an ARM
(Rockchip rk3566) platform.

The programming paradigm of these devices is similar in the following ways:
- All registers are 8 bit
- All LED control registers are write-only
- Each LED channel has a PWM register (0-255)
- PWM register writes are shadowed until an Update register is poked
- All have a concept of Software Shutdown, which disables output