### PR TITLE
arm64: dts: rockchip: rk3399-linux: delete chosen node

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
@@ -16,10 +16,6 @@
 		mmc2 = &sdio0;
 	};
 
-	chosen {
-		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 console=ttyFIQ0 rw root=PARTUUID=614e0000-0000 rootfstype=ext4 rootwait coherent_pool=1m";
-	};
-
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;


### PR DESCRIPTION
删除内核中的chosen节点，否则会影响文件系统加载。