### PR TITLE
arm64: dts: rockchip: rk356x boards: add `rockchip,dis-u2-susphy;` to…

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
@@ -492,6 +492,7 @@
 };
 
 &u2phy0_otg {
+	rockchip,dis-u2-susphy;
 	status = "okay";
 };
 
@@ -540,10 +541,6 @@
 };
 
 &usbhost30 {
-	status = "okay";
-};
-
-&u2phy0_otg {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-rock-3c.dtsi
@@ -685,6 +685,7 @@
 };
 
 &u2phy0_otg {
+	rockchip,dis-u2-susphy;
 	vbus-supply = <&vcc5v0_otg>;
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i-io.dts
@@ -119,6 +119,7 @@
 };
 
 &u2phy0_otg {
+	rockchip,dis-u2-susphy;
 	vbus-supply = <&vcc5v0_usb>;
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
@@ -154,6 +154,7 @@
 };
 
 &u2phy0_otg {
+	rockchip,dis-u2-susphy;
 	vbus-supply = <&vcc5v0_usb>;
 	status = "okay";
 };


### PR DESCRIPTION
… `u2phy0_otg`

When the USB gadget is enabled, if the USB host is not online at that time, subsequent hot-plugging will not be possible.