### PR TITLE
arm64: dts: rockchip: rk3568-linux: fix the fiq_debugger label

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-linux.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-linux.dtsi
@@ -16,7 +16,7 @@
 		bootargs = "earlycon=uart8250,mmio32,0xfe660000 console=ttyFIQ0 root=PARTUUID=614e0000-0000 rw rootwait";
 	};
 
-	fiq-debugger {
+	fiq_debugger: fiq-debugger {
 		compatible = "rockchip,fiq-debugger";
 		rockchip,serial-id = <2>;
 		rockchip,wake-irq = <0>;


### PR DESCRIPTION
cherrypick from `linux-5.10-gen-rkr4.1`
fix fiq debug overlay apply failed