### PR TITLE
arm64: dts: rockchip: rk3399: use panfrost driver as default for gpu

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
@@ -2345,6 +2345,19 @@
 	};
 
 	gpu: gpu@ff9a0000 {
+		compatible = "rockchip,rk3399-mali", "arm,mali-t860";
+		reg = <0x0 0xff9a0000 0x0 0x10000>;
+		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH 0>,
+			     <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH 0>,
+			     <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH 0>;
+		interrupt-names = "job", "mmu", "gpu";
+		clocks = <&cru ACLK_GPU>;
+		#cooling-cells = <2>;
+		power-domains = <&power RK3399_PD_GPU>;
+		status = "disabled";
+	};
+
+	gpu_mali: gpu-mali@ff9a0000 {
 		compatible = "arm,malit860",
 			     "arm,malit86x",
 			     "arm,malit8xx",
@@ -2357,6 +2370,7 @@
 		clocks = <&cru ACLK_GPU>;
 		clock-names = "clk_mali";
 		#cooling-cells = <2>;
+		operating-points-v2 = <&gpu_opp_table_mali>;
 		power-domains = <&power RK3399_PD_GPU>;
 		power-off-delay-ms = <200>;
 		upthreshold = <40>;
@@ -2365,11 +2379,40 @@
 
 		dynamic-power-coefficient = <733>;
 
-		gpu_power_model: power_model {
+		gpu_power_model_mali: power_model {
 			compatible = "arm,mali-simple-power-model";
 			static-coefficient = <411000>;
 			ts = <32000 4700 (-80) 2>;
 			thermal-zone = "gpu-thermal";
+		};
+
+		gpu_opp_table_mali: gpu-opp-table-mali {
+			compatible = "operating-points-v2";
+
+			opp00 {
+				opp-hz = /bits/ 64 <200000000>;
+				opp-microvolt = <800000>;
+			};
+			opp01 {
+				opp-hz = /bits/ 64 <297000000>;
+				opp-microvolt = <800000>;
+			};
+			opp02 {
+				opp-hz = /bits/ 64 <400000000>;
+				opp-microvolt = <825000>;
+			};
+			opp03 {
+				opp-hz = /bits/ 64 <500000000>;
+				opp-microvolt = <850000>;
+			};
+			opp04 {
+				opp-hz = /bits/ 64 <600000000>;
+				opp-microvolt = <925000>;
+			};
+			opp05 {
+				opp-hz = /bits/ 64 <800000000>;
+				opp-microvolt = <1075000>;
+			};
 		};
 	};
 


### PR DESCRIPTION
The compatible string of the panfrost driver is `arm,mali-t860` instead of `arm,malit860`.
https://github.com/radxa/kernel/blob/74729d7c051026f99138b6e0e60d580c0bf226db/drivers/gpu/drm/panfrost/panfrost_drv.c#L682