### PR TITLE
fix rk356x usb suspend issues

### DIFF
--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
@@ -3311,6 +3311,11 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 		    rport->bvalid_irq > 0)
 			enable_irq_wake(rport->bvalid_irq);
 
+		if (rport->port_id == USB2PHY_PORT_OTG) {
+			rockchip_usb2phy_enable_vbus_irq(rphy, rport, false);
+			dev_err(rphy->dev, "disable usb vbus irq\n");
+		}
+
 		/* activate the linestate to detect the next interrupt. */
 		mutex_lock(&rport->mutex);
 		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
@@ -3449,6 +3454,11 @@ static int rockchip_usb2phy_pm_resume(struct device *dev)
 		if (rport->port_id == USB2PHY_PORT_OTG && wakeup_enable &&
 		    rport->bvalid_irq > 0)
 			disable_irq_wake(rport->bvalid_irq);
+
+		if (rport->port_id == USB2PHY_PORT_OTG) {
+			rockchip_usb2phy_enable_vbus_irq(rphy, rport, true);
+			dev_err(rphy->dev, "enable usb vbus irq\n");
+		}
 
 		if (wakeup_enable && rport->ls_irq > 0)
 			disable_irq_wake(rport->ls_irq);

--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
@@ -166,6 +166,7 @@ struct rockchip_chg_det_reg {
  */
 struct rockchip_usb2phy_port_cfg {
 	struct usb2phy_reg	phy_sus;
+	struct usb2phy_reg	phy_sus_host_port;
 	struct usb2phy_reg	pipe_phystatus;
 	struct usb2phy_reg	bvalid_det_en;
 	struct usb2phy_reg	bvalid_det_st;
@@ -3264,6 +3265,7 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 	unsigned int index;
 	int ret = 0;
 	bool wakeup_enable = false;
+	struct regmap *base = get_reg_base(rphy);
 
 	if (device_may_wakeup(rphy->dev))
 		wakeup_enable = true;
@@ -3316,8 +3318,16 @@ static int rockchip_usb2phy_pm_suspend(struct device *dev)
 			dev_err(rphy->dev, "disable usb vbus irq\n");
 		}
 
-		/* activate the linestate to detect the next interrupt. */
 		mutex_lock(&rport->mutex);
+		/* because if suspend host-post can prevent suspend, so may changed phy_sus in suspend. */
+		if (rphy->phy_cfg->reg == 0xfe8a0000 && rport->port_id == USB2PHY_PORT_HOST) {
+			ret = property_enable(base, &rport->port_cfg->phy_sus_host_port, true);
+			if (ret) {
+				dev_err(rphy->dev, "failed to enable suspend host port\n");
+				return ret;
+			}
+		}
+		/* activate the linestate to detect the next interrupt. */
 		ret = rockchip_usb2phy_enable_line_irq(rphy, rport, true);
 		mutex_unlock(&rport->mutex);
 		if (ret) {
@@ -4242,6 +4252,7 @@ static const struct rockchip_usb2phy_cfg rk3568_phy_cfgs[] = {
 			[USB2PHY_PORT_HOST] = {
 				/* Select suspend control from controller */
 				.phy_sus	= { 0x0004, 8, 0, 0x1d2, 0x1d2 },
+				.phy_sus_host_port	= { 0x0004, 8, 0, 0x1d2, 0x1d1 },
 				.ls_det_en	= { 0x0080, 1, 1, 0, 1 },
 				.ls_det_st	= { 0x0084, 1, 1, 0, 1 },
 				.ls_det_clr	= { 0x0088, 1, 1, 0, 1 },


### PR DESCRIPTION
1. 当插入usb host1和hdmi时，休眠会自动唤醒
2. 只插入usb host1时，无法使用usb外设唤醒