### PR TITLE
drm/bridge: dw-mipi-dsi: Enable hsclk when sending lp cmds

### DIFF
--- a/drivers/gpu/drm/bridge/synopsys/dw-mipi-dsi.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-mipi-dsi.c
@@ -402,7 +402,7 @@ static void dw_mipi_message_config(struct dw_mipi_dsi *dsi,
 	ctrl = dsi_read(dsi, DSI_LPCLK_CTRL);
 	if (lpm) {
 		val |= ENABLE_LOW_POWER_CMD;
-		ctrl &= ~PHY_TXREQUESTCLKHS;
+		ctrl |= PHY_TXREQUESTCLKHS;
 	} else {
 		val &= ~ENABLE_LOW_POWER_CMD;
 		ctrl |= PHY_TXREQUESTCLKHS;


### PR DESCRIPTION
cherry-pick from linux-5.10-gen-rkr4.1