### PR TITLE
arm64: dts: rockchip: add 856MHz frequency and voltage configuration

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi
@@ -127,6 +127,10 @@
 			opp-microvolt = <900000>;
 		};
 		opp03 {
+			opp-hz = /bits/ 64 <856000000>;
+			opp-microvolt = <900000>;
+		};
+		opp04 {
 			opp-hz = /bits/ 64 <928000000>;
 			opp-microvolt = <925000>;
 		};


### PR DESCRIPTION
新增 856MHz 频率以及对应的电压。

主要修复连接上USB键盘，输入时提示：rockchip-dmc dmc: Get wrong frequency, Request 800000000, Current 856000000的问题。

