### PR TITLE
media: i2c: otp_eeprom: remove pd_offset in pdaf part 

### DIFF
--- a/drivers/media/i2c/gc8034.c
+++ b/drivers/media/i2c/gc8034.c
@@ -1468,7 +1468,6 @@ static void gc8034_get_otp(struct otp_info *otp,
 		inf->pdaf.flag = 1;
 		inf->pdaf.gainmap_width = otp->pdaf_data.gainmap_width;
 		inf->pdaf.gainmap_height = otp->pdaf_data.gainmap_height;
-		inf->pdaf.pd_offset = otp->pdaf_data.pd_offset;
 		inf->pdaf.dcc_mode = otp->pdaf_data.dcc_mode;
 		inf->pdaf.dcc_dir = otp->pdaf_data.dcc_dir;
 		inf->pdaf.dccmap_width = otp->pdaf_data.dccmap_width;

--- a/drivers/media/i2c/imx586.c
+++ b/drivers/media/i2c/imx586.c
@@ -1191,7 +1191,6 @@ static void imx586_get_otp(struct otp_info *otp,
 		inf->pdaf.flag = 1;
 		inf->pdaf.gainmap_width = otp->pdaf_data.gainmap_width;
 		inf->pdaf.gainmap_height = otp->pdaf_data.gainmap_height;
-		inf->pdaf.pd_offset = otp->pdaf_data.pd_offset;
 		inf->pdaf.dcc_mode = otp->pdaf_data.dcc_mode;
 		inf->pdaf.dcc_dir = otp->pdaf_data.dcc_dir;
 		inf->pdaf.dccmap_width = otp->pdaf_data.dccmap_width;

--- a/drivers/media/i2c/otp_eeprom.c
+++ b/drivers/media/i2c/otp_eeprom.c
@@ -649,11 +649,6 @@ static void rkotp_read_pdaf(struct eeprom_device *eeprom_dev,
 	checksum += otp_ptr->pdaf_data.dccmap_checksum;
 	base_addr += 1;
 
-	ret |= read_reg_otp(client, base_addr,
-		2, &otp_ptr->pdaf_data.pd_offset);
-	checksum += otp_ptr->pdaf_data.pd_offset;
-	base_addr += 2;
-
 	memset(pdaf_buf, 0, RK_PDAF_RESERVED_SIZE);
 	ret |= read_reg_otp_buf(client, base_addr,
 	       RK_PDAF_RESERVED_SIZE, pdaf_buf);
@@ -936,7 +931,6 @@ static int otp_eeprom_show(struct seq_file *p, void *v)
 			seq_printf(p, "flag=%d;\n", dev->otp->pdaf_data.flag);
 			seq_printf(p, "gainmap_width=%d;\n", gainmap_w);
 			seq_printf(p, "gainmap_height=%d;\n", gainmap_h);
-			seq_printf(p, "pd_offset=%d\n", dev->otp->pdaf_data.pd_offset);
 			seq_printf(p, "gainmap_table=\n");
 			for (i = 0; i < gainmap_h; i++) {
 				for (j = 0; j < gainmap_w; j++) {

--- a/drivers/media/i2c/otp_eeprom.h
+++ b/drivers/media/i2c/otp_eeprom.h
@@ -56,7 +56,7 @@
 #define RK_LSC_RESERVED_SIZE	0x0020
 #define RK_GAINMAP_SIZE		0x0800
 #define RK_DCCMAP_SIZE		0x0200
-#define RK_PDAF_RESERVED_SIZE	0x001e
+#define RK_PDAF_RESERVED_SIZE	0x0020
 #define RK_AF_RESERVED_SIZE	0x0014
 #define RKOTP_MAX_MODULE	0x0008
 
@@ -151,7 +151,6 @@ struct pdaf_otp_info {
 	u32 dccmap_height;
 	u32 dccmap[RK_DCCMAP_SIZE];
 	u32 dccmap_checksum;
-	u32 pd_offset;
 	u32 checksum;
 	u32 size;
 };

--- a/drivers/media/i2c/ov13855.c
+++ b/drivers/media/i2c/ov13855.c
@@ -1264,7 +1264,6 @@ static void ov13855_get_otp(struct otp_info *otp,
 		inf->pdaf.flag = 1;
 		inf->pdaf.gainmap_width = otp->pdaf_data.gainmap_width;
 		inf->pdaf.gainmap_height = otp->pdaf_data.gainmap_height;
-		inf->pdaf.pd_offset = otp->pdaf_data.pd_offset;
 		inf->pdaf.dcc_mode = otp->pdaf_data.dcc_mode;
 		inf->pdaf.dcc_dir = otp->pdaf_data.dcc_dir;
 		inf->pdaf.dccmap_width = otp->pdaf_data.dccmap_width;

--- a/drivers/media/i2c/ov50c40.c
+++ b/drivers/media/i2c/ov50c40.c
@@ -6197,7 +6197,6 @@ static void ov50c40_get_otp(struct otp_info *otp,
 		inf->pdaf.flag = 1;
 		inf->pdaf.gainmap_width = otp->pdaf_data.gainmap_width;
 		inf->pdaf.gainmap_height = otp->pdaf_data.gainmap_height;
-		inf->pdaf.pd_offset = otp->pdaf_data.pd_offset;
 		inf->pdaf.dcc_mode = otp->pdaf_data.dcc_mode;
 		inf->pdaf.dcc_dir = otp->pdaf_data.dcc_dir;
 		inf->pdaf.dccmap_width = otp->pdaf_data.dccmap_width;

--- a/drivers/media/i2c/s5kjn1.c
+++ b/drivers/media/i2c/s5kjn1.c
@@ -1259,7 +1259,6 @@ static void s5kjn1_get_otp(struct otp_info *otp,
 		inf->pdaf.flag = 1;
 		inf->pdaf.gainmap_width = otp->pdaf_data.gainmap_width;
 		inf->pdaf.gainmap_height = otp->pdaf_data.gainmap_height;
-		inf->pdaf.pd_offset = otp->pdaf_data.pd_offset;
 		inf->pdaf.dcc_mode = otp->pdaf_data.dcc_mode;
 		inf->pdaf.dcc_dir = otp->pdaf_data.dcc_dir;
 		inf->pdaf.dccmap_width = otp->pdaf_data.dccmap_width;

--- a/include/uapi/linux/rk-camera-module.h
+++ b/include/uapi/linux/rk-camera-module.h
@@ -347,7 +347,6 @@ struct rkmodule_pdaf_inf {
 	__u32 dccmap_height;
 	__u32 dcc_mode;
 	__u32 dcc_dir;
-	__u32 pd_offset;
 	__u16 gainmap[RKMODULE_PADF_GAINMAP_LEN];
 	__u16 dccmap[RKMODULE_PDAF_DCCMAP_LEN];
 } __attribute__ ((packed));


### PR DESCRIPTION
media: i2c: otp_eeprom: remove pd_offset in pdaf part

When the command rkisp_3A_server from the package camera-engine-rkisp[0][1]
is running, it will execute an ioctl with cmd RKMODULE_GET_MODULE_INFO and
a rkmodule_pdaf_inf parameter. Because the package is compiled with the
struct rkmodule_pdaf_inf without pd_offset, the ioctl will fail and
rkisp_3A_server will fail to start.

The structure of rkmodule_pdaf_inf is modified, and some driver code is
modified to ensure the code can be compiled without error.

The change is based on the commit of https://github.com/radxa/kernel/commit/31a0da2dca715c65a81fd86114cd14ef5ae84657

[0]: url: https://radxa-repo.github.io/op1-bookworm-test/pool/main/c/camera-engine-rkisp/camera_engine_rkisp_v2.3.0_arm64.deb
[1]: sha256: 2f921c70b310b81fc1af195ce95650ec0f02962de969de53cf80e6aab79e1271

Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>