### PR TITLE
Add the power-domains for the RK3576 SFC device tree node

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3576-rock-4d-spi.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-rock-4d-spi.dts
@@ -15,7 +15,7 @@
 };
 
 &sfc0 {
-	status = "okay";
+	status = "disabled";
 	max-freq = <50000000>;
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -30,7 +30,7 @@
 		spi-max-frequency = <50000000>;
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <4>;
-		status = "okay";
+		status = "disabled";
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -46,5 +46,5 @@
 };
 
 &sdhci {
-	status = "disabled";
+	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
@@ -4565,6 +4565,7 @@
 		interrupts = <GIC_SPI 255 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&cru SCLK_FSPI1_X2>, <&cru HCLK_FSPI1>;
 		clock-names = "clk_sfc", "hclk_sfc";
+		power-domains = <&power RK3576_PD_SDGMAC>;
 		rockchip,max-dll = <0xFF>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -4633,6 +4634,7 @@
 		interrupts = <GIC_SPI 254 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&cru SCLK_FSPI_X2>, <&cru HCLK_FSPI>;
 		clock-names = "clk_sfc", "hclk_sfc";
+		power-domains = <&power RK3576_PD_NVM>;
 		rockchip,max-dll = <0xFF>;
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
Add the power-domains for the RK3576 SFC nodes according to the
TRM part 1. This fixes potential SErrors when accessing the SFC
registers without other peripherals (e.g. eMMC) doing a prior
power-domain enable. For example this is easy to trigger on the
Rock 4D, which enables the SFC0 interface, but does not enable
the eMMC interface at the moment.

Cc: stable@vger.kernel.org
Fixes: 36299757129c8 ("arm64: dts: rockchip: Add SFC nodes for rk3576")
Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
---
I finally managed to get some RK3576 boards integrated to our CI
pipeline and promptly got some SError on Rock 4D with the extra
test coverage :( As we hope to get some of those boards for KernelCI,
it would be good to get this fixed in all affected trees. It seemed
enough to just describe the power-domain in DT (i.e. that fixed the
SError for the arm64 defconfig when booting the Rock 4D). If we see
further problems (I haven't so far), we might need something like
[0] for the FSPI driver.

[0] https://lore.kernel.org/all/20250423-rk3576-emmc-fix-v3-1-0bf80e29967f@collabora.com/

[   15.248915] Kernel panic - not syncing: Asynchronous SError Interrupt
[   15.248917] CPU: 7 UID: 0 PID: 142 Comm: (udev-worker) Not tainted 6.15.0-rc6-g51237a9145a9 #1 PREEMPT
[   15.248921] Hardware name: Radxa ROCK 4D (DT)
[   15.248923] Call trace:
[   15.248924]  show_stack+0x2c/0x84 (C)
[   15.248937]  dump_stack_lvl+0x60/0x80
[   15.248941]  dump_stack+0x18/0x24
[   15.248944]  panic+0x168/0x360
[   15.248948]  add_taint+0x0/0xbc
[   15.248952]  arm64_serror_panic+0x64/0x70
[   15.248956]  do_serror+0x3c/0x70
[   15.248958]  el1h_64_error_handler+0x30/0x48
[   15.248964]  el1h_64_error+0x6c/0x70
[   15.248967]  rockchip_sfc_init.isra.0+0x20/0x8c [spi_rockchip_sfc] (P)
[   15.248972]  platform_probe+0x68/0xdc
[   15.248978]  really_probe+0xc0/0x39c
[   15.248982]  __driver_probe_device+0x7c/0x14c
[   15.248985]  driver_probe_device+0x3c/0x120
[   15.248989]  __driver_attach+0xc4/0x200
[   15.248992]  bus_for_each_dev+0x7c/0xdc
[   15.248995]  driver_attach+0x24/0x30
[   15.248998]  bus_add_driver+0x110/0x240
[   15.249001]  driver_register+0x68/0x130
[   15.249005]  __platform_driver_register+0x24/0x30
[   15.249010]  rockchip_sfc_driver_init+0x20/0x1000 [spi_rockchip_sfc]
[   15.249014]  do_one_initcall+0x60/0x1e0
[   15.249017]  do_init_module+0x54/0x1fc
[   15.249021]  load_module+0x18f8/0x1e50
[   15.249024]  init_module_from_file+0x88/0xcc
[   15.249027]  __arm64_sys_finit_module+0x260/0x358
[   15.249031]  invoke_syscall+0x48/0x104
[   15.249035]  el0_svc_common.constprop.0+0x40/0xe0
[   15.249040]  do_el0_svc+0x1c/0x28
[   15.249044]  el0_svc+0x30/0xcc
[   15.249048]  el0t_64_sync_handler+0x10c/0x138
[   15.249052]  el0t_64_sync+0x198/0x19c
[   15.249057] SMP: stopping secondary CPUs
[   15.249064] Kernel Offset: 0x38f049600000 from 0xffff800080000000
[   15.249066] PHYS_OFFSET: 0xfff0e21340000000
[   15.249068] CPU features: 0x0400,00041250,01000400,0200421b
[   15.249071] Memory Limit: none
[   15.273962] ---[ end Kernel panic - not syncing: Asynchronous SError Interrupt ]---