### PR TITLE
drivers: fusb302: add function for USB3.0 signal direction selection

### DIFF
--- a/drivers/usb/typec/tcpm/fusb302.c
+++ b/drivers/usb/typec/tcpm/fusb302.c
@@ -84,6 +84,7 @@ struct fusb302_chip {
 	bool irq_suspended;
 	bool irq_while_suspended;
 	struct gpio_desc *gpio_int_n;
+	struct gpio_desc *gpio_sel;
 	int gpio_int_n_irq;
 	struct extcon_dev *extcon;
 
@@ -707,6 +708,32 @@ done:
 	mutex_unlock(&chip->lock);
 
 	return ret;
+}
+
+/*	For a single group of USB3.0, the signal direction
+	output of USB3.0 needs to be selected according to
+	the direction of TYPE C positive and negative insertion */
+static int fusb302_sel_gpio(struct fusb302_chip *chip){
+	if (!chip || IS_ERR(chip->gpio_sel)) {
+		fusb302_log(chip, "Invalid gpio_sel descriptor\n");
+		return -ENODEV;
+	}
+
+	if (chip->cc1 == TYPEC_CC_RD &&
+		(chip->cc2 == TYPEC_CC_OPEN || chip->cc2 == TYPEC_CC_RA)) {
+		gpiod_set_value(chip->gpio_sel, 0);
+	} else if (chip->cc2 == TYPEC_CC_RD &&
+		(chip->cc1 == TYPEC_CC_OPEN || chip->cc1 == TYPEC_CC_RA)) {
+		gpiod_set_value(chip->gpio_sel, 1);
+	} else if (chip->cc1 == TYPEC_CC_RA && chip->cc2 == TYPEC_CC_RD) {
+		gpiod_set_value(chip->gpio_sel, 1);
+	} else if (chip->cc1 == TYPEC_CC_RD && chip->cc2 == TYPEC_CC_RA) {
+		gpiod_set_value(chip->gpio_sel, 0);
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static int tcpm_get_cc(struct tcpc_dev *dev, enum typec_cc_status *cc1,
@@ -1629,6 +1656,12 @@ static void fusb302_irq_work(struct kthread_work *work)
 			}
 		}
 	}
+
+	ret = fusb302_sel_gpio(chip);
+	if (ret < 0) {
+		fusb302_log(chip, "failed to set gpio_sel");
+	}
+
 done:
 	mutex_unlock(&chip->lock);
 	enable_irq(chip->gpio_int_n_irq);
@@ -1739,6 +1772,11 @@ static int fusb302_probe(struct i2c_client *client,
 	INIT_DELAYED_WORK(&chip->bc_lvl_handler, fusb302_bc_lvl_handler_work);
 	init_tcpc_dev(&chip->tcpc_dev);
 	fusb302_debugfs_init(chip);
+
+	chip->gpio_sel = devm_gpiod_get_optional(dev, "sel", GPIOD_OUT_HIGH);
+	if (IS_ERR(chip->gpio_sel)) {
+		dev_err(dev, "failed to request gpio_sel\n");
+	}
 
 	if (client->irq) {
 		chip->gpio_int_n_irq = client->irq;


### PR DESCRIPTION
When USB Type-C port uses a single set of USB3.0 signals, need to select the output direction of the USB3.0 signals.

Cherrypick from linux-5.10-gen-rkr4.1