### PR TITLE
media: i2c: ov5647: replace devm_gpiod_get with devm_gpiod_get_optional

### DIFF
--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -1586,7 +1586,7 @@ static int ov5647_probe(struct i2c_client *client,
 	}
 
 	/* Request the power down GPIO asserted. */
-	sensor->pwdn = devm_gpiod_get(dev, "pwdn", GPIOD_OUT_HIGH);
+	sensor->pwdn = devm_gpiod_get_optional(dev, "pwdn", GPIOD_OUT_HIGH);
 	if (IS_ERR(sensor->pwdn)) {
 		dev_err(dev, "Failed to get 'pwdn' gpio\n");
 		return -EINVAL;


### PR DESCRIPTION
This changed is based on the upstream source code[0].

When devm_gpiod_get is used, the driver may not be probed properly as 'pwdn' gpio may not exist. Therefore devm_gpiod_get_optional is used so the probe will not fail when the 'pwdn' gpio does not exist.

[0]: https://github.com/torvalds/linux/blob/v6.1/drivers/media/i2c/ov5647.c#L1393