### PR TITLE
rk: kbuild: Introduce CONFIG_DTC_SYMBOLS

### DIFF
--- a/drivers/of/Kconfig
+++ b/drivers/of/Kconfig
@@ -12,6 +12,13 @@ menuconfig OF
 
 if OF
 
+config DTC_SYMBOLS
+	bool "Enable dtc generation of symbols for overlays support"
+	depends on DTC
+	help
+	  Set DTC_FLAGS += -@
+	  Android OS must enable this option.
+
 config OF_UNITTEST
 	bool "Device Tree runtime unit tests"
 	depends on !SPARC

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -296,6 +296,11 @@ quiet_cmd_gzip = GZIP    $@
 DTC ?= $(objtree)/scripts/dtc/dtc
 DTC_FLAGS += -Wno-interrupt_provider
 
+# Generation of symbols for Android
+ifeq ($(CONFIG_DTC_SYMBOLS),y)
+DTC_FLAGS += -@
+endif
+
 # Disable noisy checks by default
 ifeq ($(findstring 1,$(KBUILD_EXTRA_WARN)),)
 DTC_FLAGS += -Wno-unit_address_vs_reg \


### PR DESCRIPTION
dtc generation of symbols by CONFIG_DTC_SYMBOLS.
For support device tree overlay.

Change-Id: Ia10496031bc02fd3a4ff98ab0acfc6fc9a54951b