### PR TITLE
kbuild: deb-pkg: add bsp/include to kernel_headers

### DIFF
--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -61,7 +61,7 @@ deploy_kernel_headers () {
 	(
 		cd $srctree
 		find . arch/$SRCARCH -maxdepth 1 -name Makefile\*
-		find include scripts -type f -o -type l
+		find include scripts bsp/include -type f -o -type l
 		find arch/$SRCARCH -name Kbuild.platforms -o -name Platform
 		find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f
 	) > debian/hdrsrcfiles


### PR DESCRIPTION
They are part of the Allwinner kernel and are required
when compiling Allwinner's out-of-tree modules.
Link: https://applink.feishu.cn/client/message/link/open?token=Amg1LdbywUACaIsaA5diQAI%3D