### PR TITLE
drm/rockchip: vop: add hardware cursor for rk3399 vopl

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
+++ b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
@@ -742,11 +742,11 @@ static const struct vop_data rk3399_vop_big = {
 static const struct vop_win_data rk3399_vop_lit_win_data[] = {
 	{ .base = 0x00, .phy = &rk3399_win01_data, .csc = &rk3399_win0_csc,
 	  .format_modifiers = format_modifiers,
-	  .type = DRM_PLANE_TYPE_OVERLAY },
+	  .type = DRM_PLANE_TYPE_PRIMARY },
 	{ .phy = NULL },
 	{ .base = 0x00, .phy = &rk3368_win23_data, .csc = &rk3399_win2_csc,
 	  .format_modifiers = format_modifiers,
-	  .type = DRM_PLANE_TYPE_PRIMARY,
+	  .type = DRM_PLANE_TYPE_CURSOR,
 	  .area = rk3368_area_data,
 	  .area_size = ARRAY_SIZE(rk3368_area_data), },
 	{ .phy = NULL },


### PR DESCRIPTION
```
    drm/rockchip: vop: add hardware cursor for rk3399 vopl
    
    This patch adds a hardware cursor for rk3399 vopl, so the cursor on the
    screen connected to vopl will not flicker.
    
    This change has occurred in the past[0].
    
    [0]: https://github.com/radxa/kernel/commit/b759c366caf84d119aee5056e2dd3cb43c9b018b
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>
```