### PR TITLE
arm64: dts: rockchip: rk3399: add 856MHz frequency of DDR

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
@@ -315,6 +315,10 @@
 			opp-hz = /bits/ 64 <800000000>;
 			opp-microvolt = <900000>;
 		};
+		opp-856000000 {
+			opp-hz = /bits/ 64 <856000000>;
+			opp-microvolt = <900000>;
+		};
 	};
 };
 


### PR DESCRIPTION
```
    arm64: dts: rockchip: rk3399: add 856MHz frequency of DDR
    
    This change is based on [0].
    
    This change is intended to solve the issue that the serial console
    output a bunch of the following info:
    ```
    rockchip-dmc dmc: Get wrong frequency, Request 800000000, Current 856000000
    ```
    
    [0]: https://github.com/radxa/kernel/commit/0da69166157c51035647282c9e1f816496d8b66a
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>
```