### PR TITLE
mtd: spi-nor: add flash info for XT25F32B

### DIFF
--- a/drivers/mtd/spi-nor/xtx.c
+++ b/drivers/mtd/spi-nor/xtx.c
@@ -8,6 +8,9 @@
 #include "core.h"
 
 static const struct flash_info xtx_parts[] = {
+	{ "XT25F32B", INFO(0x0b4016, 0, 64 * 1024, 64)
+		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+			      SPI_NOR_QUAD_READ) },
 	{ "XT25F64F", INFO(0x0b4017, 0, 64 * 1024, 128)
 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
 			      SPI_NOR_QUAD_READ) },


### PR DESCRIPTION
    mtd: spi-nor: add flash info for XT25F32B
    
    The SPI NOR XT25F32B is supposed to be supported on ROCK 4[0]. This
    change is based on [1].
    
    [0]: https://wiki.radxa.com/Rockpi4/hardware/spi_flash
    [1]: https://github.com/radxa/kernel/commit/b1b1494e27c948a9abcaecf36de37c5b065a066b
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>