### PR TITLE
arm64: dts: rk3399: improve rock pi 4 emmc config

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -713,7 +713,8 @@
 &sdhci {
 	max-frequency = <150000000>;
 	bus-width = <8>;
-	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
 	non-removable;
 	status = "okay";
 };


### PR DESCRIPTION

    arm64: dts: rk3399: improve rock pi 4 emmc config
    
    This change is based on this commit[0].
    
    However, the property 'enable-strobe-pulldown' has already been set[1].
    We just need to set 'mmc-hs400-1_8v' and 'mmc-hs400-enhanced-strobe' in
    this change.
    
    For testing compactability, the following eMMCs were tested on Rock
    4B:
    
    Foresee 16G, 32G, 64G
    Samsung 16G, 32G, 128G
    Sandisk 8G, 16G
    
    [0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f720dd9b8b6d8b2160beda789429d5489ce8a099
    [1]: https://github.com/radxa/kernel/commit/b045498f5c40faf27485dcfa9429b8e73f9aa9ce
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>