### PR TITLE
arm64: dts: rock 4se: enable DMC

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
@@ -24,6 +24,27 @@
 	};
 };
 
+&dmc {
+	system-status-freq = <
+		/*system status         freq(KHz)*/
+		SYS_STATUS_NORMAL       666000
+		SYS_STATUS_REBOOT       666000
+		SYS_STATUS_SUSPEND      328000
+		SYS_STATUS_VIDEO_1080P  666000
+		SYS_STATUS_VIDEO_4K     666000
+		SYS_STATUS_VIDEO_4K_10B 666000
+		SYS_STATUS_PERFORMANCE  666000
+		SYS_STATUS_BOOST        666000
+		SYS_STATUS_DUALVIEW     666000
+		SYS_STATUS_ISP          666000
+	>;
+	vop-bw-dmc-freq = <
+	/* min_bw(MB/s) max_bw(MB/s) freq(KHz) */
+		0       762      416000
+		763     99999    666000
+	>;
+};
+
 &pinctrl {
 	usb2 {
 		vcc5v0_host_en: vcc5v0-host-en {

--- a/arch/arm64/boot/dts/rockchip/rk3399-t-opp.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-t-opp.dtsi
@@ -83,6 +83,48 @@
 			opp-microvolt = <975000 975000 1150000>;
 		};
 	};
+
+	dmc_opp_table: opp-table3 {
+		compatible = "operating-points-v2";
+
+		opp-200000000 {
+			opp-hz = /bits/ 64 <200000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-300000000 {
+			opp-hz = /bits/ 64 <300000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-328000000 {
+			opp-hz = /bits/ 64 <328000000>;
+			opp-microvolt = <900000>;
+		};
+		opp-400000000 {
+			opp-hz = /bits/ 64 <400000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-416000000 {
+			opp-hz = /bits/ 64 <416000000>;
+			opp-microvolt = <900000>;
+		};
+		opp-528000000 {
+			opp-hz = /bits/ 64 <528000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-600000000 {
+			opp-hz = /bits/ 64 <600000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-666000000 {
+			opp-hz = /bits/ 64 <666000000>;
+			opp-microvolt = <900000>;
+		};
+	};
 };
 
 &cpu_l0 {
@@ -107,6 +149,10 @@
 
 &cpu_b1 {
 	operating-points-v2 = <&cluster1_opp>;
+};
+
+&dmc {
+	operating-points-v2 = <&dmc_opp_table>;
 };
 
 &gpu {


### PR DESCRIPTION
    arm64: dts: rock 4se: enable DMC
    
    When connecting HDMI to a 4K display on a Rock 4SE, random black screen
    flicker occurs when playing videos. The reason was found to be that the
    DMC was not enabled.
    
    This change is cherry-picked from this commit[0].
    
    [0]: https://github.com/radxa/kernel/commit/118f10bcffe93a4632d5492f61d70fbdb74b1bee
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>