### PR TITLE
arm64: dts: rk3399-rock-4se: remove max-frequency setting for sdio0

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4se.dts
@@ -34,7 +34,6 @@
 
 &sdio0 {
 	status = "okay";
-	max-frequency = <100000000>;
 };
 
 &uart0 {


### PR DESCRIPTION
max-frequency 设置为100M，会影响WiFi速率。