### PR TITLE
arm64: dts: rock-4 : enabled `dfi` and `auto-freq-en`

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
@@ -875,6 +875,10 @@
 	//allocator = <0>;
 };
 
+&dfi {
+	status = "okay";
+};
+
 &dmc {
 	status = "okay";
 	center-supply = <&vdd_log>;
@@ -905,7 +909,6 @@
 	>;
 
 	auto-min-freq = <328000>;
-	auto-freq-en = <0>;
 };
 
 &rga {

--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
@@ -194,6 +194,10 @@
 	cpu-supply = <&vdd_cpu_b>;
 };
 
+&dfi {
+	status = "okay";
+};
+
 &dmc {
 	status = "okay";
 	center-supply = <&vdd_log>;
@@ -225,7 +229,6 @@
 	>;
 
 	auto-min-freq = <328000>;
-	auto-freq-en = <0>;
 };
 
 &emmc_phy {


### PR DESCRIPTION
They are the required items that support dmc/load