### PR TITLE
arm64: dts: rock-4c-plus: rename vbus_typec to vcc5v0_typec

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
@@ -69,13 +69,13 @@
 		vin-supply = <&vcc5v0_usb2>;
 	};
 
-	vbus_typec: vbus-typec {
+	vcc5v0_typec: vcc5v0-typec-regulator {
 		compatible = "regulator-fixed";
 		enable-active-high;
 		gpio = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
-		pinctrl-0 = <&vbus_typec_en>;
-		regulator-name = "vbus_typec";
+		pinctrl-0 = <&vcc5v0_typec_en>;
+		regulator-name = "vcc5v0_typec_en";
 		regulator-always-on;
 		regulator-boot-on;
 		vin-supply = <&vcc5v0_sys>;
@@ -1072,8 +1072,8 @@
 		};
 	};
 
-	vbus_typec {
-		vbus_typec_en: vbus-typec-en {
+	vcc5v0_typec {
+		vcc5v0_typec_en: vcc5v0-typec-en {
 			rockchip,pins =
 				<1 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
 		};


### PR DESCRIPTION
    arm64: dts: rock-4c-plus: rename vbus_typec to vcc5v0_typec
    
    The issue is that after enabling the freeing vcc5v0 typec overlay[0],
    the USB OTG port on Rock 4C+ cannot be controlled using the command
    `gpioset -m wait 1 3=<0/1>`. The reason is found to be the name
    inconsistency: the overlay expects a node labelled with 'vcc5v0_typec',
    but the Rock 4C+ device tree uses the label 'vbus_typec'.
    
    This change renames the 'vbus-typec' label to 'vcc5v0_typec' so the
    freeing vcc5v0 typec overlay will work.
    
    After this change, the output of `gpioinfo`:
    ```
    ...
    gpiochip1 - 32 lines:
            line   0:      unnamed       unused   input  active-high
            line   1:      unnamed       unused  output  active-high
            line   2:      unnamed       unused   input  active-high
            line   3:      unnamed "vcc5v0-typec-regulator" output active-high [used]
    ...
    ```
    
    Tested on Rock 4C+.
    
    [0]: https://github.com/radxa-pkg/radxa-overlays/blob/9ab948c5a0f419971a1ab9c8c1916b744f7500ed/arch/arm64/boot/dts/rockchip/overlays/rk3399-vcc5v0_typec-gpio.dts#L1-L18
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>