### PR TITLE
arm64: dts: rk3399: adjust dmc_opp_table for rk3399/op1

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi
@@ -114,25 +114,56 @@
 	dmc_opp_table: opp-table-3 {
 		compatible = "operating-points-v2";
 
-		opp00 {
-			opp-hz = /bits/ 64 <400000000>;
+		opp-200000000 {
+			opp-hz = /bits/ 64 <200000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-300000000 {
+			opp-hz = /bits/ 64 <300000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-328000000 {
+			opp-hz = /bits/ 64 <328000000>;
 			opp-microvolt = <900000>;
 		};
-		opp01 {
+		opp-400000000 {
+			opp-hz = /bits/ 64 <400000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-416000000 {
+			opp-hz = /bits/ 64 <416000000>;
+			opp-microvolt = <900000>;
+		};
+		opp-528000000 {
+			opp-hz = /bits/ 64 <528000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-600000000 {
+			opp-hz = /bits/ 64 <600000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-666000000 {
 			opp-hz = /bits/ 64 <666000000>;
 			opp-microvolt = <900000>;
 		};
-		opp02 {
+		opp-800000000 {
 			opp-hz = /bits/ 64 <800000000>;
 			opp-microvolt = <900000>;
+			status = "disabled";
 		};
-		opp03 {
+		opp-856000000 {
 			opp-hz = /bits/ 64 <856000000>;
 			opp-microvolt = <900000>;
 		};
-		opp04 {
+		opp-928000000 {
 			opp-hz = /bits/ 64 <928000000>;
-			opp-microvolt = <925000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
@@ -294,30 +294,53 @@
 		opp-200000000 {
 			opp-hz = /bits/ 64 <200000000>;
 			opp-microvolt = <900000>;
+			status = "disabled";
 		};
 		opp-300000000 {
 			opp-hz = /bits/ 64 <300000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-328000000 {
+			opp-hz = /bits/ 64 <328000000>;
 			opp-microvolt = <900000>;
 		};
 		opp-400000000 {
 			opp-hz = /bits/ 64 <400000000>;
 			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-416000000 {
+			opp-hz = /bits/ 64 <416000000>;
+			opp-microvolt = <900000>;
 		};
 		opp-528000000 {
 			opp-hz = /bits/ 64 <528000000>;
 			opp-microvolt = <900000>;
+			status = "disabled";
 		};
 		opp-600000000 {
 			opp-hz = /bits/ 64 <600000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
+		};
+		opp-666000000 {
+			opp-hz = /bits/ 64 <666000000>;
 			opp-microvolt = <900000>;
 		};
 		opp-800000000 {
 			opp-hz = /bits/ 64 <800000000>;
 			opp-microvolt = <900000>;
+			status = "disabled";
 		};
 		opp-856000000 {
 			opp-hz = /bits/ 64 <856000000>;
 			opp-microvolt = <900000>;
+		};
+		opp-928000000 {
+			opp-hz = /bits/ 64 <928000000>;
+			opp-microvolt = <900000>;
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
The currently used rkbin supports only a limited number of frequencies:
```
ddr_set_rate to 328MHZ
ddr_set_rate to 666MHZ
ddr_set_rate to 416MHZ, ctl_index 0
ddr_set_rate to 856MHZ, ctl_index 1
support 416 856 328 666 MHz, current 856MHz
OUT
```

Reference: https://github.com/radxa/kernel/commit/118f10bcffe93a4632d5492f61d70fbdb74b1bee
Issue link: https://applink.feishu.cn/client/message/link/open?token=AmgByD82iYADaQRPE%2BGRwAE%3D