### PR TITLE
media: i2c: ov9281: Fix async subdev matching for Rockchip CSI2 DPHY

### DIFF
--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -1355,7 +1355,17 @@ static int ov9281_probe(struct i2c_client *client,
 	snprintf(sd->name, sizeof(sd->name), "m%02d_%s_%s %s",
 		 ov9281->module_index, facing,
 		 OV9281_NAME, dev_name(sd->dev));
-	ret = v4l2_async_register_subdev_sensor(sd);
+	{
+                struct fwnode_handle *ep;
+                ep = fwnode_graph_get_next_endpoint(dev_fwnode(dev), NULL);
+                if (ep) {
+                        dev_info(dev, "Manually found endpoint: %px\n", ep);
+                        sd->fwnode = ep;
+                }else{
+                        dev_err(dev, "Could not find ep!\n");
+                }
+        }
+        ret = v4l2_async_register_subdev(sd);
 	if (ret) {
 		dev_err(dev, "v4l2 async register subdev failed\n");
 		goto err_clean_entity;


### PR DESCRIPTION
## Problem

The OV9281 camera sensor driver fails to work on Rockchip RK3588-based
boards (like Radxa CM5 IO) because async subdev matching never completes.

The Rockchip CSI2 DPHY driver registers an async notifier waiting for
the sensor's **endpoint fwnode**, but the ov9281 driver was registering
with its **device fwnode** via `v4l2_async_register_subdev_sensor()`.

This mismatch causes the DPHY to wait forever for the sensor, resulting in:
```
rockchip-csi2-dphy1:
[fwnode] dev=7-0060, node=/i2c@fec90000/ov9281@60/port/endpoint
```

## Solution

Set `sd->fwnode` to the sensor's endpoint fwnode before registration,
and use `v4l2_async_register_subdev()` instead of the `_sensor` variant.

## Testing

Tested on:
- **Board:** Radxa CM5 IO Board
- **SoC:** Rockchip RK3588S2
- **Camera:** OV9281 1MP Global Shutter sensor
- **Kernel:** linux-6.1-stan-rkr5

After this fix:
- Sensor properly binds to CSI2 DPHY
- Camera capture works via v4l2-ctl
- Full media pipeline is established

## Media topology after fix
`m00_b_ov9281 7-0060 → rockchip-csi2-dphy1 → rockchip-mipi-csi2 → stream_cif_mipi_id0`