### PR TITLE
Fix g12b PWM B & enable more display modes

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
@@ -207,9 +207,9 @@
 		};
 	};
 
-	pwm_b_z_pins: pwm-b-z {
+	pwm_b_z0_pins: pwm-b-z0 {
 		mux {
-			groups = "pwm_b_z";
+			groups = "pwm_b_z0";
 			function = "pwm_b";
 			bias-disable;
 		};

--- a/drivers/gpu/drm/meson/meson_vclk.c
+++ b/drivers/gpu/drm/meson/meson_vclk.c
@@ -357,6 +357,8 @@ enum {
 	MESON_VCLK_HDMI_594000,
 /* 2970 /1 /1 /1 /5 /1  => /1 /2 */
 	MESON_VCLK_HDMI_594000_YUV420,
+/* 4830 /2 /1 /2 /5 /1  => /1 /1 */
+	MESON_VCLK_HDMI_241500,
 };
 
 struct meson_vclk_params {
@@ -464,6 +466,18 @@ struct meson_vclk_params {
 		.pll_od1 = 2,
 		.pll_od2 = 1,
 		.pll_od3 = 1,
+		.vid_pll_div = VID_PLL_DIV_5,
+		.vclk_div = 1,
+	},
+	[MESON_VCLK_HDMI_241500] = {
+		.pll_freq = 4830000,
+		.phy_freq = 2415000,
+		.venc_freq = 241500,
+		.vclk_freq = 241500,
+		.pixel_freq = 241500,
+		.pll_od1 = 2,
+		.pll_od2 = 1,
+		.pll_od3 = 2,
 		.vid_pll_div = VID_PLL_DIV_5,
 		.vclk_div = 1,
 	},
@@ -893,6 +907,10 @@ static void meson_vclk_set(struct meson_drm *priv,
 		case 5940000000:
 			m = 0xf7;
 			frac = vic_alternate_clock ? 0x8148 : 0x10000;
+			break;
+		case 4830000:
+			m = 0xc9;
+			frac = 0xd560;
 			break;
 		}
 

--- a/drivers/gpu/drm/meson/meson_venc.c
+++ b/drivers/gpu/drm/meson/meson_venc.c
@@ -868,10 +868,11 @@ meson_venc_hdmi_supported_mode(const struct drm_display_mode *mode)
 			    DRM_MODE_FLAG_PVSYNC | DRM_MODE_FLAG_NVSYNC))
 		return MODE_BAD;
 
-	if (mode->hdisplay < 400 || mode->hdisplay > 1920)
+	/* support higher resolution than 1920x1080 */
+	if (mode->hdisplay < 400 || mode->hdisplay > 4096)
 		return MODE_BAD_HVALUE;
 
-	if (mode->vdisplay < 480 || mode->vdisplay > 1920)
+	if (mode->vdisplay < 400 || mode->vdisplay > 4096)
 		return MODE_BAD_VVALUE;
 
 	return MODE_OK;


### PR DESCRIPTION
Since b58ea88d301cd4c0403f298468442dacac4f8c4e, there is official support for PWM B on GPIOZ_0. However, to maintain compatibility with SM1, the group is called pwm_b_z0. This breaks our PWM overlay.

Update this pinctrl group name to match the new naming scheme.

Fixes: 5460e498d8807b5af789f9ba702200234df25d52