### PR TITLE
arm64: dts: amlogic: radxa-zero: 270 clock phase, via amlogic,mmc-phase

### DIFF
--- a/Documentation/devicetree/bindings/mmc/amlogic,meson-gx-mmc.yaml
+++ b/Documentation/devicetree/bindings/mmc/amlogic,meson-gx-mmc.yaml
@@ -54,6 +54,16 @@ properties:
   power-domains:
     maxItems: 1
 
+  amlogic,mmc-phases:
+    type: integer
+    description: |
+      3-element array of clock phases for core, tx, rx clock with values:
+      0: CLK_PHASE_0 - 0 phase
+      1: CLK_PHASE_90 - 90 phase
+      2: CLK_PHASE_180 - 180 phase
+      3: CLK_PHASE_270 - 270 phase
+      By default driver use <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0> value.
+
 required:
   - compatible
   - reg
@@ -76,4 +86,5 @@ examples:
         clock-names = "core", "clkin0", "clkin1";
         pinctrl-0 = <&emm_pins>;
         resets = <&reset_mmc>;
+        amlogic,mmc-phases = <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0>;
     };

--- a/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
@@ -13,6 +13,7 @@
 #include <dt-bindings/reset/amlogic,meson-axg-audio-arb.h>
 #include <dt-bindings/reset/amlogic,meson-axg-reset.h>
 #include <dt-bindings/power/meson-axg-power.h>
+#include <dt-bindings/mmc/meson-gx-mmc.h>
 
 / {
 	compatible = "amlogic,meson-axg";
@@ -1959,6 +1960,7 @@
 					<&clkc CLKID_SD_EMMC_B_CLK0>,
 					<&clkc CLKID_FCLK_DIV2>;
 				clock-names = "core", "clkin0", "clkin1";
+				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
 				resets = <&reset RESET_SD_EMMC_B>;
 			};
 
@@ -1972,6 +1974,7 @@
 					<&clkc CLKID_FCLK_DIV2>;
 				clock-names = "core", "clkin0", "clkin1";
 				resets = <&reset RESET_SD_EMMC_C>;
+				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
 			};
 
 			nfc: nand-controller@7800 {

--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
@@ -10,6 +10,7 @@
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
 #include <dt-bindings/usb/pd.h>
+#include <dt-bindings/mmc/meson-gx-mmc.h>
 
 / {
 	compatible = "radxa,zero", "amlogic,g12a";
@@ -477,6 +478,8 @@
 	mmc-pwrseq = <&emmc_pwrseq>;
 	vmmc-supply = <&vcc_3v3>;
 	vqmmc-supply = <&vcc_1v8>;
+
+	amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
 };
 
 &tdmif_b {

--- a/include/dt-bindings/mmc/meson-gx-mmc.h
+++ b/include/dt-bindings/mmc/meson-gx-mmc.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: (GPL-2.0+ or MIT) */
+/*
+ * Copyright (c) 2022 Vyacheslav Bocharov
+ * Author: Vyacheslav Bocharov <adeep@lexina.in>
+ */
+
+#ifndef _DT_BINDINGS_MESON_GX_MMC_H
+#define _DT_BINDINGS_MESON_GX_MMC_H
+
+/*
+ * Cfg_rx_phase: RX clock phase
+ * bits: 9:8 R/W
+ * default: 0
+ * Recommended value: 0
+ *
+ * Cfg_tx_phase: TX clock phase
+ * bits: 9:8 R/W
+ * default: 0
+ * Recommended value: 2
+ *
+ * Cfg_co_phase: Core clock phase
+ * bits: 9:8 R/W
+ * default: 0
+ * Recommended value: 2
+ *
+ * values: 0: 0 phase, 1: 90 phase, 2: 180 phase, 3: 270 phase.
+ */
+
+#define   CLK_PHASE_0 0
+#define   CLK_PHASE_90 1
+#define   CLK_PHASE_180 2
+#define   CLK_PHASE_270 3
+
+
+#endif


### PR DESCRIPTION
    arm64: dts: amlogic: radxa-zero: 270 clock phase, via amlogic,mmc-phase
    
    On the Radxa Zero with Samsung eMMC, I/O errors possibly occur when
    accessing the eMMC:
    ```
    [ 8454.110446] I/O error, dev mmcblk1, sector 64 op 0x1:(WRITE) flags 0x8800 phys_seg 62 prio class 2
    ```
    Reproduce the issue by running the following command for a few hours:
    ```
    while uptime; do echo -n "rock" | \
    sudo /usr/sbin/cryptsetup luksFormat \
        --type luks2 \
        --batch-mode /dev/mmcblk1;\
    done
    ```
    
    Configuring the MMC clock phase to 270 phase can solve the issue. Tested
    by running the above command for 7 hours and didn't see any I/O error.
    