### PR TITLE
arm64: dts: amlogic: meson-g12: add power coefficients

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
@@ -2512,6 +2512,7 @@
 			resets = <&reset RESET_DVALIN_CAPB3>, <&reset RESET_DVALIN>;
 			operating-points-v2 = <&gpu_opp_table>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <400>;
 		};
 	};
 
@@ -2520,6 +2521,7 @@
 			polling-delay = <1000>;
 			polling-delay-passive = <100>;
 			thermal-sensors = <&cpu_temp>;
+			sustainable-power = <3000>; /* 3000mW */
 
 			trips {
 				cpu_passive: cpu-passive {
@@ -2546,6 +2548,7 @@
 			polling-delay = <1000>;
 			polling-delay-passive = <100>;
 			thermal-sensors = <&ddr_temp>;
+			sustainable-power = <2000>; /* 2000mW */
 
 			trips {
 				ddr_passive: ddr-passive {

--- a/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi
@@ -25,6 +25,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		cpu1: cpu@1 {
@@ -40,6 +41,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		cpu2: cpu@2 {
@@ -55,6 +57,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		cpu3: cpu@3 {
@@ -70,6 +73,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		l2: l2-cache0 {

--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
@@ -57,6 +57,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2_cache_l>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		cpu1: cpu@1 {
@@ -73,6 +74,7 @@
 			i-cache-sets = <32>;
 			next-level-cache = <&l2_cache_l>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <140>;
 		};
 
 		cpu100: cpu@100 {
@@ -89,6 +91,7 @@
 			i-cache-sets = <64>;
 			next-level-cache = <&l2_cache_b>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <430>;
 		};
 
 		cpu101: cpu@101 {
@@ -105,6 +108,7 @@
 			i-cache-sets = <64>;
 			next-level-cache = <&l2_cache_b>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <430>;
 		};
 
 		cpu102: cpu@102 {
@@ -121,6 +125,7 @@
 			i-cache-sets = <64>;
 			next-level-cache = <&l2_cache_b>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <430>;
 		};
 
 		cpu103: cpu@103 {
@@ -137,6 +142,7 @@
 			i-cache-sets = <64>;
 			next-level-cache = <&l2_cache_b>;
 			#cooling-cells = <2>;
+			dynamic-power-coefficient = <430>;
 		};
 
 		l2_cache_l: l2-cache-cluster0 {


### PR DESCRIPTION
Add dynamic-power-coefficient for CPU cores and GPU, and sustainable-power for CPU and DDR thermal zones on Amlogic G12A and G12B SoCs.

The dynamic-power-coefficient is used by the Energy Model framework to estimate the dynamic power consumption of a device, and the sustainable-power represents the thermal dissipation capacity of the system. Both are needed by the power allocator thermal governor to perform intelligent power allocation.