### PR TITLE
DPTSW-23172: firmware: arm_scmi: Exclude platform devices from bus matching

### DIFF
--- a/drivers/firmware/arm_scmi/bus.c
+++ b/drivers/firmware/arm_scmi/bus.c
@@ -224,7 +224,9 @@ static int scmi_match_by_id_table(struct device *dev, void *data)
 	struct scmi_device *sdev = to_scmi_dev(dev);
 	struct scmi_device_id *id_table = data;
 
+	/* Only check scmi protocol devices */
 	return sdev->protocol_id == id_table->protocol_id &&
+		!strncmp(dev->bus->name, "scmi_protocol", 13) &&
 		(id_table->name && !strcmp(sdev->name, id_table->name));
 }
 


### PR DESCRIPTION
We get a kernel panic caused by accessing invalid mem address of sdev->name in scmi_match_by_id_table(). scmi_match_by_id_table() will match both devices like "scmi_dev.1" created by scmi protocol and devices like "CIXHA008:00" from ACPI asl. And sometimes sdev->protocol_id which is converted by to_scmi_dev() from platform devices like "CIXHA008:00" happens to equal id_table->protocol_id, then we get a kernel panic since converted scmi_device doesn't have valid sdev->name.

To fix it, only match devices created by scmi protocol.

Without this patch, cix is fixing the issue via disabling scmi protocol nodes in ACPI asl. After this patch, we can re-enable the scmi protocol nodes so that mainline linux can create scmi protocols in normal way.