### PR TITLE
drm: panel: jd9365da: set refresh rate to 59.94Hz for radxa_display_8hd_ad002

### DIFF
--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
@@ -381,7 +381,7 @@ static int radxa_display_8hd_ad002_init_cmds(struct jadard *jadard)
 
 static const struct jadard_panel_desc radxa_display_8hd_ad002_desc = {
 	.mode = {
-		.clock		= 70000,
+		.clock		= 71804,
 
 		.hdisplay	= 800,
 		.hsync_start	= 800 + 40,


### PR DESCRIPTION
The radxa_display_8hd_ad002 panel fails to display when configured at
60.000Hz, resulting in a blank screen on both Radxa Dragon Q6A and
Radxa Zero 2 Pro platforms. Empirical testing confirms that 59.94Hz
works reliably on both devices.
    
Update pixel clock to 71804 kHz, calculated as:
(800 + 40 + 18 + 40) * (1280 + 20 + 4 + 30) * 59.94 / 1000 ≈ 71804 kHz
    
This matches the actual hardware capability and resolves blank screen on boot.

Issue: radxa-docs/docs/issues/1355