### PR TITLE
arm64: dts: rockchip: Add dynamic-power-coefficient to rk3399 GPU

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
@@ -2352,6 +2352,9 @@
 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH 0>,
 			     <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH 0>,
 			     <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH 0>;
+
+		dynamic-power-coefficient = <2640>;
+
 		interrupt-names = "job", "mmu", "gpu";
 		clocks = <&cru ACLK_GPU>;
 		#cooling-cells = <2>;


### PR DESCRIPTION
    arm64: dts: rockchip: Add dynamic-power-coefficient to rk3399 GPU
    
    On a Radxa Rock 4B+ board, when executing the following stress test
    command for a few hours:
    glmark2-es2 -b refract:duration=60 -s 3840x2160 --off-screen --run-forever
    
    The SoC temperature will increase gradually until it reaches the
    critical temperature and triggers shutdown.
    Kernel log:
    kernel: thermal thermal_zone1: gpu-thermal: critical temperature reached, shutting down
    kernel: reboot: HARDWARE PROTECTION shutdown (Temperature too high)
    
    The reason is that the device tree gpu node does not provide a
    dynamic-power-coefficient; without this value, the gpu cooling device is
    not registered[0][1], so it will reach the critical temperature.
    
    The value 2640 is based on this upstream patch:
    https://lore.kernel.org/all/20231127081511.1911706-1-lukasz.luba@arm.com
    
    [0]: https://github.com/radxa/kernel/blob/8582469f117fdfd5d1ab88fa7e4e15c3b714bf24/drivers/thermal/devfreq_cooling.c#L484-L489
    [1]: https://github.com/radxa/kernel/blob/8582469f117fdfd5d1ab88fa7e4e15c3b714bf24/drivers/opp/of.c#L1594-L1606