### PR TITLE
arm64: dts: rock-4c-plus: optimize usb0 device tree

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
@@ -54,8 +54,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&vcc5v0_host_en>;
 		regulator-name = "vbus_host";
-		regulator-always-on;
-		regulator-boot-on;
 		vin-supply = <&vcc5v0_usb2>;
 	};
 
@@ -66,8 +64,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&vcc5v0_typec_en>;
 		regulator-name = "vcc5v0_typec_en";
-		regulator-always-on;
-		regulator-boot-on;
 		vin-supply = <&vcc5v0_sys>;
 	};
 
@@ -717,6 +713,7 @@
 	wakeup-source;
 
 	u2phy0_otg: otg-port {
+		vbus-supply = <&vcc5v0_typec>; 
 		status = "okay";
 	};
 
@@ -762,6 +759,7 @@
 
 &usbdrd_dwc3_0 {
 	dr_mode = "host";
+	extcon = <&u2phy0>;
 	status = "okay";
 };
 


### PR DESCRIPTION
To support USB3 when device overlay is enabled