### PR TITLE
arm64: dts: rockchip: cm3j-rpi-cm4: use emc2305,*

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3j-rpi-cm4-io.dts
@@ -141,15 +141,11 @@
 		status = "okay";
 		compatible = "microchip,emc2301";
 		reg = <0x2f>;
-		#address-cells = <1>;
-		#size-cells = <0>;
 		#cooling-cells = <2>;
-		microchip,pwm-separate;
-		microchip,cooling-levels = <10>;
-		channel@0 {
-			reg = <0>;
-			pwm-min = <0>;
-		};
+		emc2305,pwm-min = /bits/ 8 <0>;
+		emc2305,pwm-max = /bits/ 8 <255>;
+		emc2305,pwm-channel = /bits/ 8 <0>;
+		emc2305,cooling-levels = /bits/ 8 <10>;
 	};
 
 	pcf85063: pcf85063@51 {


### PR DESCRIPTION
    arm64: dts: rockchip: cm3j-rpi-cm4: use emc2305,*
    
    The microchip,emc2301 driver accepts the following properties[0]:
    emc2305,cooling-levels
    emc2305,pwm-max
    emc2305,pwm-min
    emc2305,pwm-channel
    
    Because `of_property_read_u8`[0] is used, the 8 bits type needs to be
    explicitly stated.
    
    [0]: https://github.com/radxa/kernel/blob/e7976b5c9bd2f34e21d3cc871f54d67470e1ec42/drivers/hwmon/emc2305.c#L311-L333
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>