### PR TITLE
[PATCH] media: ov5647: Allow optional PWDN GPIO

### DIFF
--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -1586,7 +1586,7 @@ static int ov5647_probe(struct i2c_client *client,
 	}
 
 	/* Request the power down GPIO asserted. */
-	sensor->pwdn = devm_gpiod_get(dev, "pwdn", GPIOD_OUT_HIGH);
+	sensor->pwdn = devm_gpiod_get_optional(dev, "pwdn", GPIOD_OUT_HIGH);
 	if (IS_ERR(sensor->pwdn)) {
 		dev_err(dev, "Failed to get 'pwdn' gpio\n");
 		return -EINVAL;


### PR DESCRIPTION
    [PATCH] media: ov5647: Allow optional PWDN GPIO
    
    According to the upstream and 6.1.y LTS code, the property 'pwdn-gpios'
    is optional[0][1].
    
    [0]: https://github.com/torvalds/linux/blob/5d6919055dec134de3c40167a490f33c74c12581/Documentation/devicetree/bindings/media/i2c/ovti%2Cov5647.yaml
    [1]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/devicetree/bindings/media/i2c/ovti%2Cov5647.yaml?h=linux-6.1.y
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>