### PR TITLE
kbuild: install-extmod-build: add bsp/include to kernel headers

### DIFF
--- a/scripts/package/install-extmod-build
+++ b/scripts/package/install-extmod-build
@@ -18,7 +18,7 @@ mkdir -p "${destdir}"
 	cd "${srctree}"
 	echo Makefile
 	find "arch/${SRCARCH}" -maxdepth 1 -name 'Makefile*'
-	find include scripts -type f -o -type l
+	find include scripts bsp/include -type f -o -type l
 	find "arch/${SRCARCH}" -name Kbuild.platforms -o -name Platform
 	find "arch/${SRCARCH}" -name include -o -name scripts -type d
 ) | tar -c -f - -C "${srctree}" -T - | tar -xf - -C "${destdir}"
@@ -28,7 +28,7 @@ mkdir -p "${destdir}"
 		echo tools/objtool/objtool
 	fi
 
-	find "arch/${SRCARCH}/include" Module.symvers include scripts -type f
+	find "arch/${SRCARCH}/include" Module.symvers include scripts bsp/include -type f
 
 	if is_enabled CONFIG_GCC_PLUGINS; then
 		find scripts/gcc-plugins -name '*.so'


### PR DESCRIPTION
Include Allwinner BSP headers when installing extmod build dependencies, required for compiling out-of-tree modules.

Link: https://github.com/radxa/kernel/commit/74c3d3bc168fdd38d02bb4b1ac422da81feed527