### PR TITLE
drm/msm/dpu: Prevent unnecessary hardware block migration

### DIFF
--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c
+++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c
@@ -1443,16 +1443,20 @@ static int dpu_crtc_assign_resources(struct drm_crtc *crtc,
 	int ret;
 
 	/*
-	 * Release and Allocate resources on every modeset
+	 * When disabling a CRTC, release all its hardware resources.
+	 * When re-reserving for an enabled CRTC (e.g. during modeset),
+	 * do NOT release first — dpu_rm_reserve will prefer the existing
+	 * assignment, preventing unnecessary block migration that can
+	 * break vblank IRQ registration.
 	 */
 	global_state = dpu_kms_get_global_state(crtc_state->state);
 	if (IS_ERR(global_state))
 		return PTR_ERR(global_state);
 
-	dpu_rm_release(global_state, crtc);
-
-	if (!crtc_state->enable)
+	if (!crtc_state->enable) {
+		dpu_rm_release(global_state, crtc);
 		return 0;
+	}
 
 	topology = dpu_crtc_get_topology(crtc, dpu_kms, crtc_state);
 	ret = dpu_rm_reserve(&dpu_kms->rm, global_state,

--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c
+++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c
@@ -366,7 +366,63 @@ static int _dpu_rm_reserve_lms(struct dpu_rm *rm,
 		return -EINVAL;
 	}
 
-	/* Find a primary mixer */
+	/*
+	 * First pass: prefer LMs already assigned to this CRTC.
+	 * Skip the capability check — these LMs were already working
+	 * and may have been assigned under a different topology (e.g.
+	 * boot-time topology with num_dspp=0 vs hotplug topology with
+	 * num_dspp>0).  Changing the assignment would trigger an
+	 * unnecessary modeset and break vblank IRQ registration.
+	 */
+	for (i = 0; i < ARRAY_SIZE(rm->mixer_blks) &&
+			lm_count < topology->num_lm; i++) {
+		if (!rm->mixer_blks[i])
+			continue;
+
+		if (global_state->mixer_to_crtc_id[i] != crtc_id)
+			continue;
+
+		lm_count &= ~1;
+		lm_idx[lm_count] = i;
+
+		/*
+		 * For existing LMs, skip the connected-blocks check.
+		 * The HW was already configured and working; re-validating
+		 * against the current topology may reject valid assignments
+		 * (e.g. DSPP_-1 when topology->num_dspp changed).
+		 */
+		pp_idx[lm_count] = to_dpu_hw_mixer(rm->mixer_blks[i])->cap->pingpong - PINGPONG_0;
+		if (topology->num_dspp) {
+			int d = to_dpu_hw_mixer(rm->mixer_blks[i])->cap->dspp - DSPP_0;
+			dspp_idx[lm_count] = (d >= 0 && d < ARRAY_SIZE(rm->dspp_blks)) ? d : 0;
+		}
+
+		++lm_count;
+
+		/* Valid primary mixer found, find matching peer */
+		if (lm_count < topology->num_lm) {
+			int j = _dpu_rm_get_lm_peer(rm, i);
+
+			if (j < 0 || j < i)
+				continue;
+
+			if (!rm->mixer_blks[j])
+				continue;
+
+			if (global_state->mixer_to_crtc_id[j] != crtc_id)
+				continue;
+
+			lm_idx[lm_count] = j;
+			pp_idx[lm_count] = to_dpu_hw_mixer(rm->mixer_blks[j])->cap->pingpong - PINGPONG_0;
+			if (topology->num_dspp) {
+				int d = to_dpu_hw_mixer(rm->mixer_blks[j])->cap->dspp - DSPP_0;
+				dspp_idx[lm_count] = (d >= 0 && d < ARRAY_SIZE(rm->dspp_blks)) ? d : 0;
+			}
+			++lm_count;
+		}
+	}
+
+	/* Second pass: find LMs from the free pool */
 	for (i = 0; i < ARRAY_SIZE(rm->mixer_blks) &&
 			lm_count < topology->num_lm; i++) {
 		if (!rm->mixer_blks[i])
@@ -452,7 +508,37 @@ static int _dpu_rm_reserve_ctls(
 		needs_split_display = false;
 	}
 
-	for (j = 0; j < ARRAY_SIZE(rm->ctl_blks); j++) {
+	/*
+	 * First pass: prefer CTLs already assigned to this CRTC.
+	 * This avoids unnecessary reassignment when another CRTC
+	 * releases its CTL (e.g. during hot-unplug), which would
+	 * otherwise cause the lowest-numbered free CTL to be
+	 * picked and trigger a spurious modeset on this CRTC.
+	 */
+	for (j = 0; j < ARRAY_SIZE(rm->ctl_blks) && i < num_ctls; j++) {
+		const struct dpu_hw_ctl *ctl;
+		unsigned long features;
+		bool has_split_display;
+
+		if (!rm->ctl_blks[j])
+			continue;
+		if (global_state->ctl_to_crtc_id[j] != crtc_id)
+			continue;
+
+		ctl = to_dpu_hw_ctl(rm->ctl_blks[j]);
+		features = ctl->caps->features;
+		has_split_display = BIT(DPU_CTL_SPLIT_DISPLAY) & features;
+
+		if (needs_split_display != has_split_display)
+			continue;
+
+		ctl_idx[i] = j;
+		DPU_DEBUG("CTL_%d match (existing)\n", j);
+		i++;
+	}
+
+	/* Second pass: fill remaining from free pool */
+	for (j = 0; j < ARRAY_SIZE(rm->ctl_blks) && i < num_ctls; j++) {
 		const struct dpu_hw_ctl *ctl;
 		unsigned long features;
 		bool has_split_display;
@@ -473,10 +559,7 @@ static int _dpu_rm_reserve_ctls(
 
 		ctl_idx[i] = j;
 		DPU_DEBUG("CTL_%d match\n", j);
-
-		if (++i == num_ctls)
-			break;
-
+		i++;
 	}
 
 	if (i != num_ctls)


### PR DESCRIPTION
When one CRTC is disabled during Type-C hot-unplug, the DPU Resource Manager would unnecessarily reassign hardware blocks (CTL, LM, DSPP) for the remaining active CRTC.  The sequence:

  1. crtc-0's dpu_rm_release() frees ctl-0, LM-0/1
  2. crtc-1's dpu_crtc_assign_resources() releases ctl-1/LM-2/3 then calls dpu_rm_reserve()
  3. _dpu_rm_reserve_ctls() scans from j=0, finds ctl-0 free, assigns it to crtc-1 instead of keeping ctl-1
  4. _dpu_rm_reserve_lms() does the same for LM blocks
  5. The hardware pipeline migration triggers a modeset that disables/re-enables the encoder, but vblank IRQ callbacks are not properly re-registered (cb:0x0 in core_irq debugfs)
  6. INTF hardware continues generating vsync but interrupts go unhandled, causing the display to freeze

Fix by:
  - In dpu_crtc_assign_resources(): only release resources when the CRTC is being disabled, not on every modeset.  For enabled CRTCs, let dpu_rm_reserve() retain the existing assignment.
  - In _dpu_rm_reserve_ctls() and _dpu_rm_reserve_lms(): use a two-pass approach that first prefers hardware blocks already assigned to this CRTC, then falls back to the free pool.