### PR TITLE
drivers: usb: dwc3: Extend core mapping to LLUCTL

### DIFF
--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -1999,7 +1999,8 @@ int dwc3_probe(struct dwc3 *dwc,
 	 */
 	dwc_res = *res;
 	dwc_res.start += DWC3_GLOBALS_REGS_START;
-	dwc_res.end = res->start + DWC3_OTG_REGS_END;
+	dwc_res.end = min_t(resource_size_t, res->end,
+			    res->start + DWC3_LLUCTL_REGS_END);
 
 	if (dev->of_node) {
 		struct device_node *parent = of_get_parent(dev->of_node);

--- a/drivers/usb/dwc3/core.h
+++ b/drivers/usb/dwc3/core.h
@@ -83,6 +83,8 @@
 #define DWC3_DEVICE_REGS_END		0xcbff
 #define DWC3_OTG_REGS_START		0xcc00
 #define DWC3_OTG_REGS_END		0xccff
+/* DWC_usb31 LLUCTL sits past the OTG register block. */
+#define DWC3_LLUCTL_REGS_END		0xda00
 
 #define DWC3_RTK_RTD_GLOBALS_REGS_START	0x8100
 


### PR DESCRIPTION
The DWC_usb31 LLUCTL register is accessed when the core forces Gen1 speed for maximum-speed = "super-speed".

Map the core register window far enough to cover LLUCTL while still clamping to the parent resource end.