### PR TITLE
arm64: dts: qcom: disable PMIC RTC

### DIFF
--- a/arch/arm64/boot/dts/qcom/sc8280xp-radxa-dragon-q8b.dts
+++ b/arch/arm64/boot/dts/qcom/sc8280xp-radxa-dragon-q8b.dts
@@ -1285,8 +1285,6 @@
 
 &pmk8280_rtc {
 	qcom,uefi-rtc-info;
-
-	status = "okay";
 };
 
 &pmk8280_vadc {


### PR DESCRIPTION
PMIC RTC is not backed by battery. I2C RTC is the primary RTC on this device.