### PR TITLE
drm/msm/dp: notify audio subsystem when display is hot plugged

### DIFF
--- a/drivers/gpu/drm/msm/dp/dp_display.c
+++ b/drivers/gpu/drm/msm/dp/dp_display.c
@@ -385,21 +385,33 @@ static int msm_dp_display_handle_irq_hpd(struct msm_dp_display_private *dp)
 	return 0;
 }
 
+static void msm_dp_display_handle_plugged_change(struct msm_dp *msm_dp_display,
+		bool plugged);
+
 static void msm_dp_hpd_recovery_work(struct work_struct *work)
 {
 	struct delayed_work *dw = to_delayed_work(work);
 	struct msm_dp_display_private *dp =
 		container_of(dw, struct msm_dp_display_private, hpd_recovery_work);
+	int rc;
+
+	mutex_lock(&dp->plugged_lock);
 
 	if (!dp->msm_dp_display.power_on || !dp->plugged)
-		return;
+		goto unlock;
 
 	msm_dp_ctrl_off_link_stream(dp->ctrl);
 	msm_dp_ctrl_on_link(dp->ctrl);
-	msm_dp_ctrl_on_stream(dp->ctrl, false);
+	rc = msm_dp_ctrl_on_stream(dp->ctrl, false);
+	if (rc)
+		goto unlock;
 
 	drm_connector_set_link_status_property(dp->msm_dp_display.connector,
 					       DRM_MODE_LINK_STATUS_GOOD);
+	msm_dp_display_handle_plugged_change(&dp->msm_dp_display, true);
+
+unlock:
+	mutex_unlock(&dp->plugged_lock);
 }
 
 static int msm_dp_hpd_plug_handle(struct msm_dp_display_private *dp)


### PR DESCRIPTION
Currently when using Type-C to HDMI adapter, the audio device is only available when HDMI was already connected to the adapter before it was connected.

Add the plumbing to notify audio subsystem.

Also add check and lock to ensure we only trigger events when we actually have a working stream.

修复`左侧Type-C口接hub转HDMI插拔无法识别声卡，靠板边的Type-C口接hub转HDMI无法识别声卡，两个Type-C口接USB-C TO DP 插拔可以识别声卡`，应该对`HDMI插拔无法识别声卡`问题也有帮助